### PR TITLE
Use env to find node

### DIFF
--- a/src/signalling-server/bin.js
+++ b/src/signalling-server/bin.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 'use strict'
 


### PR DESCRIPTION
Not everyone has a `/usr/local/bin/node`. I have (on Ubuntu 16.04) only a `/usr/bin/node`. The current shebang just produces this:

```
$ star-sig
bash: /usr/bin/star-sig: /usr/local/bin/node: bad interpreter: No such file or directory
```

I am currently having to run

```
node `which star-sig`
```

instead.

This change uses `/usr/bin/env` to go find a `node` to run the script, which I think is best practice. Everyone *should* have a `/usr/bin/env`, the purpose of which is to solve this problem of finding your interpreter.