### PR TITLE
Added signaling error handling to webrtc-star transport

### DIFF
--- a/src/webrtc-star/index.js
+++ b/src/webrtc-star/index.js
@@ -75,6 +75,10 @@ function WebRTCStar () {
     })
 
     sioClient.on('ws-handshake', (offer) => {
+      if (offer.intentId === intentId && offer.err) {
+        return callback(new Error(offer.err))
+      }
+
       if (offer.intentId !== intentId || !offer.answer) {
         return
       }
@@ -135,7 +139,7 @@ function WebRTCStar () {
       })
 
       function incommingDial (offer) {
-        if (offer.answer) {
+        if (offer.answer || offer.err) {
           return
         }
 

--- a/test/webrtc-star/test-dial.js
+++ b/test/webrtc-star/test-dial.js
@@ -59,6 +59,13 @@ describe('dial', () => {
       )
     })
   })
+  it('dial offline / non-existent node on IPv4, check callback', (done) => {
+    let maOffline = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.1/tcp/15555/ws/ipfs/ABCD')
+    ws1.dial(maOffline, (err, conn) => {
+      expect(err).to.exist
+      done()
+    })
+  })
 
   it.skip('dial on IPv6', (done) => {
     // TODO IPv6 not supported yet


### PR DESCRIPTION
Hey All,

Errors from the signaling server are not currently being handled. They are simply ignored, this PR adds error handling and a simple test to ensure this does not break in the future.
Previously without the error handling, dialing an offline node caused extremely undesirable effects, part of which was a connection being established from the initiating node to itself by the means of two different instances of SimplePeer. Then, the undesirable connection was returned to the caller of dial as the connection to the offline node.
This is also likely a part of the fix to this issue too. #5  

Thanks