### PR TITLE
Segmentation Fault Repro case

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "peer-id": "^0.8.1",
     "peer-info": "^0.8.2",
     "pull-stream": "^3.5.0",
+    "segfault-handler": "^1.0.0",
     "simple-peer": "6.2.1",
     "socket.io": "^1.7.2",
     "socket.io-client": "^1.7.2",

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ const PeerInfo = require('peer-info')
 const Connection = require('interface-connection').Connection
 const toPull = require('stream-to-pull-stream')
 const once = require('once')
+const SegfaultHandler = require('segfault-handler')
+SegfaultHandler.registerHandler('crash.log')
 
 const noop = once(() => {})
 
@@ -77,7 +79,7 @@ class WebRTCStar {
 
     // NOTE: aegir segfaults if we do .once on the socket.io event emitter and we
     // are clueless as to why.
-    sioClient.on('ws-handshake', (offer) => {
+    sioClient.once('ws-handshake', (offer) => {
       if (offer.intentId === intentId && offer.err) {
         return callback(new Error(offer.err))
       }


### PR DESCRIPTION
This needs to be reported to nodejs core + socket.io. It would be good to provide a little more information, since this only happens with the aegir gulp pipeline, when running `npm test`

How to reproduce:

```sh
> git clone git@github.com:libp2p/js-libp2p-webrtc-star.git -b segfault
> cd js-libp2p-webrtc-star
> npm i
> npm test
```

Current output:

```sh
#...
PID 31271 received SIGSEGV for address: 0x69
0   segfault-handler.node               0x0000000101ff9588 _ZL16segfault_handleriP9__siginfoPv + 280
1   libsystem_platform.dylib            0x00007fff9933fbba _sigtramp + 26
2   ???                                 0x00000e695272a1a1 0x0 + 15845517599137
3   node                                0x0000000100a59080 uv__async_event + 198
4   node                                0x0000000100a59213 uv__async_io + 136
5   node                                0x0000000100a685e8 uv__io_poll + 1621
6   node                                0x0000000100a596c7 uv_run + 321
7   node                                0x00000001008d0755 _ZN4node5StartEiPPc + 660
8   node                                0x0000000100001734 start + 52
```