### PR TITLE
A few BUGFIXES and new tests to cover those scenarios + multiple signalling servers!

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const gulp = require('gulp')
+const parallel = require('async/parallel')
 const sigServer = require('./src/sig-server')
 
-let sigS
+let sigS, sigS2
 
 gulp.task('test:node:before', boot)
 gulp.task('test:node:after', stop)
@@ -15,19 +16,47 @@ function boot (done) {
     port: 15555,
     host: '127.0.0.1'
   }
+  const options2 = {
+    port: 15556,
+    host: '127.0.0.1'
+  }
 
-  sigServer.start(options, (err, server) => {
-    if (err) {
-      throw err
-    }
-    sigS = server
-    console.log('signalling on:', server.info.uri)
-    done()
-  })
+  parallel([
+    first,
+    second
+  ], done)
+  function first (cb) {
+    sigServer.start(options, (err, server) => {
+      if (err) {
+        throw err
+      }
+      sigS = server
+      console.log('signalling on:', server.info.uri)
+      cb()
+    })
+  }
+  function second (cb) {
+    sigServer.start(options2, (err, server) => {
+      if (err) {
+        throw err
+      }
+      sigS2 = server
+      console.log('signalling 2 on:', server.info.uri)
+      cb()
+    })
+  }
 }
-
 function stop (done) {
-  sigS.stop(done)
+  parallel([
+    first,
+    second
+  ], done)
+  function first (cb) {
+    sigS.stop(() => cb())
+  }
+  function second (cb) {
+    sigS2.stop(() => cb())
+  }
 }
 
 require('aegir/gulp')(gulp)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const gulp = require('gulp')
-const parallel = require('async/parallel')
+const forEach = require('async/each')
 const sigServer = require('./src/sig-server')
 
-let sigS, sigS2
+let sigServers = []
 
 gulp.task('test:node:before', boot)
 gulp.task('test:node:after', stop)
@@ -12,51 +12,33 @@ gulp.task('test:browser:before', boot)
 gulp.task('test:browser:after', stop)
 
 function boot (done) {
-  const options = {
-    port: 15555,
-    host: '127.0.0.1'
-  }
-  const options2 = {
-    port: 15556,
-    host: '127.0.0.1'
-  }
+  const options = [
+    {
+      port: 15555,
+      host: '127.0.0.1'
+    },
+    {
+      port: 15556,
+      host: '127.0.0.1'
+    }]
 
-  parallel([
-    first,
-    second
-  ], done)
-  function first (cb) {
+  forEach(options, (options, cb) => {
     sigServer.start(options, (err, server) => {
       if (err) {
         throw err
       }
-      sigS = server
+      sigServers.push(server)
       console.log('signalling on:', server.info.uri)
       cb()
     })
-  }
-  function second (cb) {
-    sigServer.start(options2, (err, server) => {
-      if (err) {
-        throw err
-      }
-      sigS2 = server
-      console.log('signalling 2 on:', server.info.uri)
-      cb()
-    })
-  }
+  }, done)
 }
+
 function stop (done) {
-  parallel([
-    first,
-    second
-  ], done)
-  function first (cb) {
-    sigS.stop(() => cb())
-  }
-  function second (cb) {
-    sigS2.stop(() => cb())
-  }
+  forEach(sigServers, (sigS, cb) => {
+    sigS.stop()
+    cb()
+  }, done)
 }
 
 require('aegir/gulp')(gulp)

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class WebRTCStar {
 
     const intentId = (~~(Math.random() * 1e9)).toString(36) + Date.now()
     const keys = Object.keys(this.listenersRefs)
-                          .filter((key) => cleanUrlSIO(ma) === cleanUrlSIO(multiaddr(key)))
+        .filter((key) => cleanUrlSIO(ma) === cleanUrlSIO(multiaddr(key)))
     const listener = this.listenersRefs[keys[0]]
     if (!listener) return callback(new Error('signalling server not connected'))
     const sioClient = listener.io

--- a/test/transport/listen.spec.js
+++ b/test/transport/listen.spec.js
@@ -48,6 +48,16 @@ describe('listen', () => {
     })
   })
 
+  it('listen on offline signalling server should error', (done) => {
+    let maOfflineSigServer = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.0/tcp/15555/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooooA')
+    const listener = ws.createListener((conn) => {})
+    listener.listen(maOfflineSigServer, (err) => {
+      expect(err).to.exist
+      listener.once('close', done)
+      listener.close()
+    })
+  })
+
   it.skip('close listener with connections, through timeout', (done) => {
     // TODO ? Should this apply ?
   })


### PR DESCRIPTION
Continuing https://github.com/libp2p/js-libp2p-webrtc-star/pull/54

A few mishaps and that branch is no longer merge-able, so I created this new and cleaner branch 

Here is a summary of all the changes:

- Variable maSelf was redirecting all dials to come back through the last added listener. This definitely does not make any sense, since the last added listener will most likely be another signalling server which will have a completely different multi-address. This means that the peer will never get the answer for the offer creating an error state on the server side and on the peer's side.
- Closing the listener did not close the socket connection to the signalling server. This safe to do at the moment since each listener creates a new socket connection to be used.
- Moved the close and getObservedAddr functions to be added only when the listen function is called since they do not make any sense if the listener is not listening.There is no multi-address to return or a listener to close if its not listening.
- Fixed ss-leave event which did not pass the multi-address to the server
- Fixed an issue where the listener was added with a function as the key to the listeners map/array
- Moved adding the listener to the listeners array to occur only once its connected to the signalling server, otherwise its just have a bad listener that cannot actually dial anywhere
- Part of this PR addresses Websocket stays connected even after webrtc-star listener is closed #51

- EDIT: This PR also adds support for handling multiple signalling servers
Let me know if you need me to make any changes.