### PR TITLE
Rediscovering Peers after Network Interruption

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ class WebRTCStar {
         listener.emit('listening')
         callback()
       })
-      
+
       listener.io.on('reconnect', () => {
         listener.io.emit('ss-join', ma.toString())
       })

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,10 @@ class WebRTCStar {
         listener.emit('listening')
         callback()
       })
+      
+      listener.io.on('reconnect', () => {
+        listener.io.emit('ss-join', ma.toString())
+      })
 
       function incommingDial (offer) {
         if (offer.answer || offer.err) {


### PR DESCRIPTION
At the moment, this transport sends out an introductory message (`ss-join`) exactly once when first establishing a connection go the signalling server over websocket, which is then discovered by every senior node. 

However, this means if the node ever loses connection it will not only lose all its peers but also the connection to the signalling server. The websocket connection to the signalling server is restored automatically by socket.io, but since this event triggers no further introductory messages, other nodes cannot rediscover this newly reset node, and it remains without peers unless a _newer_ peer is created and discovered by everyone.

This can be fixed by sending the intro message not just _once_ when the initial socket-io `connect`ion is established with the signalling server, but also _every time_ the socket `reconnect`s.

This change has been enough to address my issues with using js-ipfs (and also orbit-db) with unstable connections. I am quite new to this, so if this is entirely wrong or not right enough, please advise.