### PR TITLE
signaling server: send fresh peer list to each node every 10 seconds

### DIFF
--- a/src/sig-server/config.js
+++ b/src/sig-server/config.js
@@ -16,5 +16,6 @@ module.exports = {
         }
       }
     }
-  }
+  },
+  refreshPeerListIntervalMS: 10000
 }

--- a/test/sig-server.js
+++ b/test/sig-server.js
@@ -126,7 +126,7 @@ describe('signalling', () => {
   })
 
   it('ss-join the fourth', (done) => {
-    c1.on('ws-peer', (multiaddr) => {
+    c1.once('ws-peer', (multiaddr) => {
       expect(multiaddr).to.equal(c4mh.toString())
       expect(Object.keys(sigS.peers()).length).to.equal(2)
       done()
@@ -164,6 +164,32 @@ describe('signalling', () => {
     })
   })
 
+  it('disconnects every client', (done) => {
+    [c1, c2, c3, c4].forEach((c) => c.disconnect())
+    done()
+  })
+
+  it('emits ws-peer every 10 seconds', (done) => {
+    let addr = 0
+    let peersEmitted = 0
+
+    c1 = io.connect(sioUrl, sioOptions)
+    c2 = io.connect(sioUrl, sioOptions)
+    c1.emit('ss-join', 'c1')
+    c2.emit('ss-join', 'c2')
+
+    c1.on('ws-peer', (p) => {
+      expect(p).to.be.equal('c2')
+      peersEmitted ++
+    })
+
+    setTimeout(() => {
+      expect(peersEmitted).to.equal(2)
+      done()
+    }, 11000)
+  })
+
+
   it('stop signalling server', (done) => {
     parallel([
       (cb) => {
@@ -179,10 +205,10 @@ describe('signalling', () => {
       //  c3.disconnect()
       //  cb()
       // },
-      (cb) => {
-        c4.disconnect()
-        cb()
-      }
+      // (cb) => {
+      //   c4.disconnect()
+      //   cb()
+      // }
     ], () => {
       sigS.stop(done)
     })

--- a/test/sig-server.js
+++ b/test/sig-server.js
@@ -170,7 +170,6 @@ describe('signalling', () => {
   })
 
   it('emits ws-peer every 10 seconds', (done) => {
-    let addr = 0
     let peersEmitted = 0
 
     c1 = io.connect(sioUrl, sioOptions)
@@ -180,7 +179,7 @@ describe('signalling', () => {
 
     c1.on('ws-peer', (p) => {
       expect(p).to.be.equal('c2')
-      peersEmitted ++
+      peersEmitted++
     })
 
     setTimeout(() => {
@@ -188,7 +187,6 @@ describe('signalling', () => {
       done()
     }, 11000)
   })
-
 
   it('stop signalling server', (done) => {
     parallel([
@@ -199,7 +197,7 @@ describe('signalling', () => {
       (cb) => {
         c2.disconnect()
         cb()
-      },
+      }
       // done in test
       // (cb) => {
       //  c3.disconnect()


### PR DESCRIPTION
I'm building a demo using IPFS, and when testing several scenarios, IPFS was apparently unable to recover from this:

When disconnecting the network temporarily, the WebRTC peer connections disconnect shortly after. But the WS connection to the Signaling Server lingers on for a while.
Once the network is available again, each peer does not reconnect to the other known peers.

This change on the Signaling Server allows the node to get a fresh list of peers and reconnect.