### PR TITLE
fix: handle reconnection to signaling server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,9 @@ class WebRTCStar {
 
       listener.io.on('connect', () => {
         listener.io.emit('ss-join', ma.toString())
+      })
+
+      listener.io.once('connect', () => {
         listener.emit('listening')
         callback()
       })

--- a/src/index.js
+++ b/src/index.js
@@ -155,10 +155,11 @@ class WebRTCStar {
         listener.emit('close')
       })
 
-      listener.io.once('connect', () => {
+      listener.io.on('ws-handshake', incommingDial)
+      listener.io.on('ws-peer', this._peerDiscovered)
+
+      listener.io.on('connect', () => {
         listener.io.emit('ss-join', ma.toString())
-        listener.io.on('ws-handshake', incommingDial)
-        listener.io.on('ws-peer', this._peerDiscovered)
         listener.emit('listening')
         callback()
       })

--- a/test/node.js
+++ b/test/node.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
 'use strict'
 
 require('./sig-server.js')
+require('./transport/reconnect.node.js')

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -1,0 +1,87 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const multiaddr = require('multiaddr')
+const webrtcSupport = require('webrtcsupport')
+const isNode = require('detect-node')
+const WebRTCStar = require('../../src')
+const sigServer = require('../../src/sig-server')
+
+const SERVER_PORT = 13580
+
+describe('reconnect to signaling server', () => {
+  if (!webrtcSupport.support && !isNode) {
+    return console.log('WebRTC not available')
+  }
+
+  let sigS
+  let ws1
+  const ma1 = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.1/tcp/13580/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo6A')
+
+  let ws2
+  const ma2 = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.1/tcp/13580/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo6B')
+
+  let ws3
+  const ma3 = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.1/tcp/13580/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo6C')
+
+  before((done) => {
+    sigS = sigServer.start({ port: SERVER_PORT }, done)
+  })
+
+  after((done) => {
+    sigS.stop(done)
+  })
+
+  it('listen on the first', (done) => {
+    ws1 = new WebRTCStar()
+
+    const listener = ws1.createListener((conn) => {})
+    listener.listen(ma1, (err) => {
+      expect(err).to.not.exist()
+      done()
+    })
+  })
+
+  it('listen on the second, discover the first', (done) => {
+    ws2 = new WebRTCStar()
+
+    ws1.discovery.once('peer', (peerInfo) => {
+      expect(peerInfo.multiaddrs.has(ma2)).to.equal(true)
+      done()
+    })
+
+    const listener = ws2.createListener((conn) => {})
+    listener.listen(ma2, (err) => {
+      expect(err).to.not.exist()
+    })
+  })
+
+  it('stops the server', (done) => {
+    sigS.stop(done)
+  })
+
+  it('starts the server again', (done) => {
+    sigS = sigServer.start({ port: SERVER_PORT }, done)
+  })
+
+  it('wait a bit for clients to reconnect', (done) => {
+    setTimeout(done, 2000)
+  })
+
+  it('listen on the third, first discovers it', (done) => {
+    ws3 = new WebRTCStar()
+
+    const listener = ws3.createListener((conn) => {})
+    listener.listen(ma3, (err) => expect(err).to.not.exist())
+
+    ws1.discovery.once('peer', (peerInfo) => {
+      expect(peerInfo.multiaddrs.has(ma3)).to.equal(true)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
If a connection to the signalling server dies and then recovers, Socket.io emits the `connect` event again.
It happens that the peer was ignoring it. This fixes it.