### PR TITLE
Fix: /dns4 multiaddr explicit tcp/port support

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,19 +4,24 @@ const multiaddr = require('multiaddr')
 
 function cleanUrlSIO (ma) {
   const maStrSplit = ma.toString().split('/')
+  const tcpProto = ma.protos()[1].name
+  const wsProto = ma.protos()[2].name
+  const tcpPort = ma.stringTuples()[1][1]
+
+  if (tcpProto !== 'tcp' || (wsProto !== 'ws' && wsProto !== 'wss')) {
+    throw new Error('invalid multiaddr: ' + ma.toString())
+  }
 
   if (!multiaddr.isName(ma)) {
     return 'http://' + maStrSplit[2] + ':' + maStrSplit[4]
-  } else {
-    const wsProto = ma.protos()[1].name
+  }
 
-    if (wsProto === 'ws') {
-      return 'http://' + maStrSplit[2]
-    } else if (wsProto === 'wss') {
-      return 'https://' + maStrSplit[2]
-    } else {
-      throw new Error('invalid multiaddr' + ma.toString())
-    }
+  if (wsProto === 'ws') {
+    return 'http://' + maStrSplit[2] + (tcpPort === 80 ? '' : ':' + tcpPort)
+  }
+
+  if (wsProto === 'wss') {
+    return 'https://' + maStrSplit[2] + (tcpPort === 443 ? '' : ':' + tcpPort)
   }
 }
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -6,14 +6,51 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
+const multiaddr = require('multiaddr')
 const cleanMultiaddr = require('../src/utils').cleanMultiaddr
+const cleanUrlSIO = require('../src/utils').cleanUrlSIO
 
 describe('utils', () => {
-  const legacyMultiaddrStringDNS = '/libp2p-webrtc-star/dns4/star-signal.cloud.ipfs.team/wss/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const legacyMultiaddrStringDNS = '/libp2p-webrtc-star/dns4/star-signal.cloud.ipfs.team/tcp/443/wss/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
   const legacyMultiaddrStringIP = '/libp2p-webrtc-star/ip4/127.0.0.1/tcp/1212/wss/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
 
-  const modernMultiaddrStringDNS = '/dns4/star-signal.cloud.ipfs.team/wss/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const modernMultiaddrStringDNS = '/dns4/star-signal.cloud.ipfs.team/tcp/443/wss/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
   const modernMultiaddrStringIP = '/ip4/127.0.0.1/tcp/1212/wss/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+
+  const modernMultiaddrStringDNS2 = '/dns4/star-signal.cloud.ipfs.team/tcp/9999/wss/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const modernMultiaddrStringDNS3 = '/dns4/star-signal.cloud.ipfs.team/tcp/80/ws/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const modernMultiaddrStringDNS4 = '/dns4/star-signal.cloud.ipfs.team/tcp/8080/ws/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+
+  const invalidMultiaddrStringDNS = '/dns4/star-signal.cloud.ipfs.team/udp/8080/wss/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const invalidMultiaddrStringDNS2 = '/dns4/star-signal.cloud.ipfs.team/tcp/8080/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+  const invalidMultiaddrStringDNS3 = '/dns4/star-signal.cloud.ipfs.team/ws/p2p-webrtc-star/ipfs/QmWxLfixekyv6GAzvDEtXfXjj7gb1z3G8i5aQNHLhw1zA1'
+
+  // Create actual multiaddrs
+  const modernMultiaddrDNS = multiaddr(modernMultiaddrStringDNS)
+  const modernMultiaddrDNS2 = multiaddr(modernMultiaddrStringDNS2)
+  const modernMultiaddrDNS3 = multiaddr(modernMultiaddrStringDNS3)
+  const modernMultiaddrDNS4 = multiaddr(modernMultiaddrStringDNS4)
+
+  const invalidMultiaddrDNS = multiaddr(invalidMultiaddrStringDNS)
+  const invalidMultiaddrDNS2 = multiaddr(invalidMultiaddrStringDNS2)
+  const invalidMultiaddrDNS3 = multiaddr(invalidMultiaddrStringDNS3)
+
+  it('cleanUrlSIO webrtc-star modern', () => {
+    const newUrlSIOStringDNS = cleanUrlSIO(modernMultiaddrDNS)
+    const newUrlSIOStringDNS2 = cleanUrlSIO(modernMultiaddrDNS2)
+    const newUrlSIOStringDNS3 = cleanUrlSIO(modernMultiaddrDNS3)
+    const newUrlSIOStringDNS4 = cleanUrlSIO(modernMultiaddrDNS4)
+
+    expect(() => cleanUrlSIO(modernMultiaddrDNS)).to.not.throw()
+    expect(() => cleanUrlSIO(invalidMultiaddrDNS)).to.throw(Error, 'invalid multiaddr')
+    expect(() => cleanUrlSIO(invalidMultiaddrDNS2)).to.throw(Error, 'invalid multiaddr')
+    expect(() => cleanUrlSIO(invalidMultiaddrDNS3)).to.throw(Error, 'invalid multiaddr')
+
+    expect(newUrlSIOStringDNS).to.equal('https://star-signal.cloud.ipfs.team')
+    expect(newUrlSIOStringDNS2).to.equal('https://star-signal.cloud.ipfs.team:9999')
+    expect(newUrlSIOStringDNS3).to.equal('http://star-signal.cloud.ipfs.team')
+    expect(newUrlSIOStringDNS4).to.equal('http://star-signal.cloud.ipfs.team:8080')
+  })
 
   it('cleanMultiaddr webrtc-star legacy', () => {
     const newMultiaddrStringDNS = cleanMultiaddr(legacyMultiaddrStringDNS)


### PR DESCRIPTION
# Summary
This is my attempt to add explicit TCP/Port support (also my first PR ever): https://github.com/libp2p/js-libp2p-webrtc-star/issues/129
## Fixed
- /dn4: Should work... I think. Test cases added as well.
## Not fixed
- /ip4: Should also work, but it allows implicit TCP/Port (will look at it tomorrow, out of battery :))
## Haven't looked at
- /dns6
- /ip6
# Comments
Aegir gave me problems because of WebRTC.

I'm not sure if created the test cases properly. So double check that.
Some TCP/Ports are bogus, but I don't think it's actually trying to dial them, so that's ok.

Default ports probably won't show as an explicit port by design.

Regarding /ip4, is it because of https://github.com/whyrusleeping/js-mafmt/blob/9df8d849e405ef8765e09897aba6c3c89e270572/src/index.js#L26-L34? (Just guessing)

https://github.com/whyrusleeping/js-mafmt/blob/9df8d849e405ef8765e09897aba6c3c89e270572/test/index.spec.js have a few invalid multiaddrs that is added to the "good" list (if TCP/Port must be explicit)
