### PR TITLE
chore: update wrtc

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "electron-webrtc": "~0.3.0",
     "lodash": "^4.17.10",
     "mafmt": "^6.0.0",
-    "wrtc": "0.1.1"
+    "wrtc": "~0.1.6"
   },
   "dependencies": {
     "async": "^2.6.1",


### PR DESCRIPTION
relates to https://github.com/libp2p/js-libp2p/pull/211

The new version of wrtc, 0.1.6, fixes an issue that was breaking usage in wrtc >= 0.1.2.

Electron-wrtc tests are still having issues (unrelated to this PR), but this gets CI another step closer to full green.