### PR TITLE
fix: catch RTCPeerConnection failed connections

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,13 @@ class WebRTCStar {
     // Use custom WebRTC implementation
     if (this.wrtc) { spOptions.wrtc = this.wrtc }
 
-    const channel = new SimplePeer(spOptions)
+    let channel
+    try {
+      channel = new SimplePeer(spOptions)
+    } catch (err) {
+      log('Could not create connection:', err)
+      return callback(err)
+    }
 
     const conn = new Connection(toPull.duplex(channel))
     let connected = false
@@ -168,7 +174,13 @@ class WebRTCStar {
         // Use custom WebRTC implementation
         if (self.wrtc) { spOptions.wrtc = self.wrtc }
 
-        const channel = new SimplePeer(spOptions)
+        let channel
+        try {
+          channel = new SimplePeer(spOptions)
+        } catch (err) {
+          log('Could not create incoming connection:', err)
+          return callback(err)
+        }
 
         const conn = new Connection(toPull.duplex(channel))
 


### PR DESCRIPTION
Resolves https://github.com/ipfs/js-ipfs/issues/1561

There are issues with rtc connection cleanup in chrome, https://github.com/ipfs/js-ipfs/issues/1561#issuecomment-421080057, that result in errors being thrown when too many connections are attempted. 

This catches and logs those thrown errors as well as returning the error in the callback.

**Note**: CI errors are due to an ongoing issue with electron-wrtc.