### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-webrtc-star.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-webrtc-star)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-webrtc-star.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-webrtc-star)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-webrtc-star.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-webrtc-star) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
     "prom-client": "^11.2.1",
-    "wrtc": "~0.3.5"
+    "wrtc": "~0.3.7"
   },
   "dependencies": {
     "async": "^2.6.2",
@@ -68,10 +68,10 @@
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "pull-stream": "^3.6.9",
-    "simple-peer": "^9.2.1",
+    "simple-peer": "^9.3.0",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.1.1",
-    "stream-to-pull-stream": "^1.7.2",
+    "stream-to-pull-stream": "^1.7.3",
     "webrtcsupport": "github:ipfs/webrtcsupport"
   },
   "contributors": [


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated