### PR TITLE
fix: update hapi

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -4,26 +4,26 @@ const sigServer = require('./src/sig-server')
 let firstRun = true
 let sigS
 
-function boot (done) {
+async function boot (done) {
   const options = {
     port: 15555,
     host: '127.0.0.1',
-    metrics: firstRun
+    metrics: false // firsrun TODO: needs https://github.com/libp2p/js-libp2p-webrtc-star/issues/174
   }
 
   if (firstRun) { firstRun = false }
 
-  sigServer.start(options, (err, server) => {
-    if (err) { throw err }
+  sigS = await sigServer.start(options)
 
-    sigS = server
-    console.log('signalling on:', server.info.uri)
-    done()
-  })
+  console.log('signalling on:', sigS.info.uri)
+
+  done()
 }
 
-function stop (done) {
-  sigS.stop(done)
+async function stop (done) {
+  await sigS.stop()
+
+  done()
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "wrtc": "~0.3.7"
   },
   "dependencies": {
+    "@hapi/hapi": "^18.3.1",
+    "@hapi/inert": "^5.2.0",
     "async": "^2.6.2",
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "epimetheus": "^1.0.92",
-    "hapi": "^16.6.2",
-    "inert": "^4.2.1",
     "interface-connection": "~0.3.3",
     "mafmt": "^6.0.7",
     "minimist": "^1.2.0",

--- a/src/sig-server/bin.js
+++ b/src/sig-server/bin.js
@@ -5,24 +5,19 @@
 const signalling = require('./index')
 const argv = require('minimist')(process.argv.slice(2))
 
-let server
-
-signalling.start({
-  port: argv.port || argv.p || process.env.PORT || 9090,
-  host: argv.host || argv.h || process.env.HOST || '0.0.0.0',
-  metrics: !(argv.disableMetrics || process.env.DISABLE_METRICS)
-}, (err, _server) => {
-  if (err) {
-    throw err
-  }
-  server = _server
+;(async () => {
+  const server = await signalling.start({
+    port: argv.port || argv.p || process.env.PORT || 9090,
+    host: argv.host || argv.h || process.env.HOST || '0.0.0.0',
+    // Needs: https://github.com/libp2p/js-libp2p-webrtc-star/issues/174'
+    metrics: false // !(argv.disableMetrics || process.env.DISABLE_METRICS)
+  })
 
   console.log('Listening on:', server.info.uri)
-})
 
-process.on('SIGINT', () => {
-  server.stop(() => {
+  process.on('SIGINT', async () => {
+    await server.stop()
     console.log('Signalling server stopped')
     process.exit()
   })
-})
+})()

--- a/src/sig-server/config.js
+++ b/src/sig-server/config.js
@@ -10,10 +10,8 @@ module.exports = {
     port: process.env.PORT || 13579,
     host: '0.0.0.0',
     options: {
-      connections: {
-        routes: {
-          cors: true
-        }
+      routes: {
+        cors: true
       }
     }
   },

--- a/src/sig-server/index.js
+++ b/src/sig-server/index.js
@@ -1,6 +1,10 @@
+/* eslint no-unreachable: "warn" */
+
 'use strict'
 
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
+const Inert = require('@hapi/inert')
+
 const config = require('./config')
 const log = config.log
 const epimetheus = require('epimetheus')
@@ -8,49 +12,37 @@ const path = require('path')
 
 exports = module.exports
 
-exports.start = (options, callback) => {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
-  }
-
+exports.start = async (options = {}) => {
   const port = options.port || config.hapi.port
   const host = options.host || config.hapi.host
 
-  const http = new Hapi.Server(config.hapi.options)
-
-  http.connection({
-    port: port,
-    host: host
+  const http = new Hapi.Server({
+    ...config.hapi.options,
+    port,
+    host
   })
 
-  http.register({ register: require('inert') }, (err) => {
-    if (err) {
-      return callback(err)
-    }
+  await http.register(Inert)
+  await http.start()
 
-    http.start((err) => {
-      if (err) {
-        return callback(err)
-      }
+  log('signaling server has started on: ' + http.info.uri)
 
-      log('signaling server has started on: ' + http.info.uri)
+  http.peers = require('./routes-ws')(http, options.metrics).peers
 
-      http.peers = require('./routes-ws')(http, options.metrics).peers
-
-      http.route({
-        method: 'GET',
-        path: '/',
-        handler: (request, reply) => reply.file(path.join(__dirname, 'index.html'), {
-          confine: false
-        })
-      })
-
-      callback(null, http)
+  http.route({
+    method: 'GET',
+    path: '/',
+    handler: (request, reply) => reply.file(path.join(__dirname, 'index.html'), {
+      confine: false
     })
-
-    if (options.metrics) { epimetheus.instrument(http) }
   })
+
+  if (options.metrics) {
+    // TODO: reenable epimatheus when support
+    log('wait for epimeteus support')
+    throw new Error('epimeteus is currently not supported by hapi. Needs: https://github.com/libp2p/js-libp2p-webrtc-star/issues/174')
+    epimetheus.instrument(http)
+  }
 
   return http
 }

--- a/src/sig-server/index.js
+++ b/src/sig-server/index.js
@@ -38,9 +38,9 @@ exports.start = async (options = {}) => {
   })
 
   if (options.metrics) {
-    // TODO: reenable epimatheus when support
-    log('wait for epimeteus support')
-    throw new Error('epimeteus is currently not supported by hapi. Needs: https://github.com/libp2p/js-libp2p-webrtc-star/issues/174')
+    // TODO: reenable epimetheus when support
+    log('wait for epimetheus support')
+    throw new Error('epimetheus is currently not supported by hapi. Needs: https://github.com/libp2p/js-libp2p-webrtc-star/issues/174')
     epimetheus.instrument(http)
   }
 

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -27,11 +27,13 @@ module.exports = (create) => {
     const ma2 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3B'))
     const ma3 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3C'))
 
-    before((done) => {
-      sigS = sigServer.start({ port: SERVER_PORT }, done)
+    before(async () => {
+      sigS = await sigServer.start({ port: SERVER_PORT })
     })
 
-    after((done) => sigS.stop(done))
+    after(async () => {
+      await sigS.stop()
+    })
 
     it('listen on the first', (done) => {
       ws1 = create()
@@ -57,12 +59,12 @@ module.exports = (create) => {
       })
     })
 
-    it('stops the server', (done) => {
-      sigS.stop(done)
+    it('stops the server', async () => {
+      await sigS.stop()
     })
 
-    it('starts the server again', (done) => {
-      sigS = sigServer.start({ port: SERVER_PORT }, done)
+    it('starts the server again', async () => {
+      sigS = await sigServer.start({ port: SERVER_PORT })
     })
 
     it('wait a bit for clients to reconnect', (done) => {


### PR DESCRIPTION
For security and performance reasons, Hapi updated from v16 to v18. The hapi implementation moved from callbacks to promises and the code for the signaling server was refactored to use async await instead.

Moreover, in this PR I had to throw an error if metrics are enabled as the current implementation of `epimetheus` is not compatible with the new implementation of hapi. I created an issue to track this #174  

Closes #172 