### PR TITLE
feat: start/stop discovery events when start/stop called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ class WebRTCStar {
 
     this.discovery = new EE()
     this.discovery.tag = 'webRTCStar'
-    this.discovery._isStarted = true
+    this.discovery._isStarted = false
     this.discovery.start = (callback) => {
       this.discovery._isStarted = true
       setImmediate(callback)

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,15 @@ class WebRTCStar {
 
     this.discovery = new EE()
     this.discovery.tag = 'webRTCStar'
-    this.discovery.start = (callback) => { setImmediate(callback) }
-    this.discovery.stop = (callback) => { setImmediate(callback) }
+    this.discovery._isStarted = true
+    this.discovery.start = (callback) => {
+      this.discovery._isStarted = true
+      setImmediate(callback)
+    }
+    this.discovery.stop = (callback) => {
+      this.discovery._isStarted = false
+      setImmediate(callback)
+    }
 
     this.listenersRefs = {}
     this._peerDiscovered = this._peerDiscovered.bind(this)
@@ -237,6 +244,8 @@ class WebRTCStar {
   }
 
   _peerDiscovered (maStr) {
+    if (!this.discovery._isStarted) return
+
     log('Peer Discovered:', maStr)
     maStr = cleanMultiaddr(maStr)
 

--- a/test/transport/discovery.js
+++ b/test/transport/discovery.js
@@ -11,6 +11,7 @@ const multiaddr = require('multiaddr')
 module.exports = (create) => {
   describe('peer discovery', () => {
     let ws1
+    let ws1Listener
     const base = (id) => {
       return `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/${id}`
     }
@@ -19,10 +20,17 @@ module.exports = (create) => {
     let ws2
     const ma2 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3B'))
 
+    let ws3
+    const ma3 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3C'))
+
+    let ws4
+    const ma4 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3D'))
+
     it('listen on the first', (done) => {
       ws1 = create()
 
       const listener = ws1.createListener((conn) => {})
+      ws1Listener = listener
       listener.listen(ma1, (err) => {
         expect(err).to.not.exist()
         done()
@@ -40,6 +48,49 @@ module.exports = (create) => {
       const listener = ws2.createListener((conn) => {})
       listener.listen(ma2, (err) => {
         expect(err).to.not.exist()
+      })
+    })
+
+    // this test is mostly validating the non-discovery test mechanism works
+    it('listen on the third, verify ws-peer is discovered', (done) => {
+      ws3 = create()
+      let discoveredPeer = false
+
+      // resolve on peer discovered
+      ws1.discovery.once('peer', (peerInfo) => {
+        discoveredPeer = true
+      })
+      ws1Listener.io.once('ws-peer', (maStr) => {
+        expect(discoveredPeer).to.equal(true)
+        done()
+      })
+
+      const listener = ws3.createListener((conn) => {})
+      listener.listen(ma3, (err) => {
+        expect(err).to.not.exist()
+      })
+    })
+
+    it('listen on the fourth, ws-peer is not discovered', (done) => {
+      ws4 = create()
+      ws1.discovery.stop((err) => {
+        expect(err).to.not.exist()
+
+        let discoveredPeer = false
+
+        // resolve on peer discovered
+        ws1.discovery.once('peer', (peerInfo) => {
+          discoveredPeer = true
+        })
+        ws1Listener.io.once('ws-peer', (maStr) => {
+          expect(discoveredPeer).to.equal(false)
+          done()
+        })
+
+        const listener = ws4.createListener((conn) => {})
+        listener.listen(ma4, (err) => {
+          expect(err).to.not.exist()
+        })
       })
     })
   })

--- a/test/transport/discovery.js
+++ b/test/transport/discovery.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
+const series = require('async/series')
 
 module.exports = (create) => {
   describe('peer discovery', () => {
@@ -27,35 +28,47 @@ module.exports = (create) => {
     const ma4 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3D'))
 
     it('listen on the first', (done) => {
-      ws1 = create()
-
-      const listener = ws1.createListener((conn) => {})
-      ws1Listener = listener
-      listener.listen(ma1, (err) => {
+      series([
+        (cb) => {
+          ws1 = create()
+          ws1Listener = ws1.createListener((conn) => {})
+          ws1.discovery.start(cb)
+        },
+        (cb) => {
+          ws1Listener.listen(ma1, cb)
+        }
+      ], (err) => {
         expect(err).to.not.exist()
         done()
       })
     })
 
     it('listen on the second, discover the first', (done) => {
-      ws2 = create()
+      let listener
 
       ws1.discovery.once('peer', (peerInfo) => {
         expect(peerInfo.multiaddrs.has(ma2)).to.equal(true)
         done()
       })
 
-      const listener = ws2.createListener((conn) => {})
-      listener.listen(ma2, (err) => {
+      series([
+        (cb) => {
+          ws2 = create()
+          listener = ws2.createListener((conn) => {})
+          ws2.discovery.start(cb)
+        },
+        (cb) => {
+          listener.listen(ma2, cb)
+        }
+      ], (err) => {
         expect(err).to.not.exist()
       })
     })
 
     // this test is mostly validating the non-discovery test mechanism works
     it('listen on the third, verify ws-peer is discovered', (done) => {
-      ws3 = create()
+      let listener
       let discoveredPeer = false
-
       // resolve on peer discovered
       ws1.discovery.once('peer', (peerInfo) => {
         discoveredPeer = true
@@ -65,32 +78,46 @@ module.exports = (create) => {
         done()
       })
 
-      const listener = ws3.createListener((conn) => {})
-      listener.listen(ma3, (err) => {
+      series([
+        (cb) => {
+          ws3 = create()
+          listener = ws3.createListener((conn) => {})
+          ws3.discovery.start(cb)
+        },
+        (cb) => {
+          listener.listen(ma3, cb)
+        }
+      ], (err) => {
         expect(err).to.not.exist()
       })
     })
 
     it('listen on the fourth, ws-peer is not discovered', (done) => {
-      ws4 = create()
-      ws1.discovery.stop((err) => {
+      let listener
+      let discoveredPeer = false
+      // resolve on peer discovered
+      ws1.discovery.once('peer', (peerInfo) => {
+        discoveredPeer = true
+      })
+      ws1Listener.io.once('ws-peer', (maStr) => {
+        expect(discoveredPeer).to.equal(false)
+        done()
+      })
+
+      series([
+        (cb) => {
+          ws1.discovery.stop(cb)
+        },
+        (cb) => {
+          ws4 = create()
+          listener = ws4.createListener((conn) => {})
+          ws4.discovery.start(cb)
+        },
+        (cb) => {
+          listener.listen(ma4, cb)
+        }
+      ], (err) => {
         expect(err).to.not.exist()
-
-        let discoveredPeer = false
-
-        // resolve on peer discovered
-        ws1.discovery.once('peer', (peerInfo) => {
-          discoveredPeer = true
-        })
-        ws1Listener.io.once('ws-peer', (maStr) => {
-          expect(discoveredPeer).to.equal(false)
-          done()
-        })
-
-        const listener = ws4.createListener((conn) => {})
-        listener.listen(ma4, (err) => {
-          expect(err).to.not.exist()
-        })
       })
     })
   })

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -3,6 +3,7 @@
 'use strict'
 
 const chai = require('chai')
+const series = require('async/series')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -37,7 +38,10 @@ module.exports = (create) => {
       ws1 = create()
 
       const listener = ws1.createListener((conn) => {})
-      listener.listen(ma1, (err) => {
+      series([
+        (cb) => ws1.discovery.start(cb),
+        (cb) => listener.listen(ma1, cb)
+      ], (err) => {
         expect(err).to.not.exist()
         done()
       })


### PR DESCRIPTION
Fixes #175 

wanted to be able to disable certain discovery methods at runtime, noticed I was unable to stop this one