### PR TITLE
Generate Typescript Typings via JsDoc 

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,12 @@
+{
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src/"],
+        "exclude": ["node_modules"]
+    },
+    "opts": {
+        "destination": "src/",
+        "template": "./node_modules/tsd-jsdoc/dist",
+        "recurse": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
         - npx aegir commitlint --travis
         - npx aegir dep-check -- -i wrtc -i electron-webrtc
         - npm run lint
+        - npm run generate-typings
 
     - stage: test
       name: chrome

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "libp2p WebRTC transport that includes a discovery mechanism provided by the signalling-star",
   "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",
+  "typings": "src/types.d.ts",
   "bin": {
     "webrtc-star": "src/sig-server/bin.js",
     "star-sig": "src/sig-server/bin.js",
@@ -22,7 +23,8 @@
     "release-minor": "aegir release --type minor -t node -t browser",
     "release-major": "aegir release --type major -t node -t browser",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "coverage-publish": "aegir coverage --provider coveralls",
+    "generate-typings": "./node_modules/.bin/jsdoc -c ./.jsdoc.json"
   },
   "pre-push": [
     "lint",
@@ -50,7 +52,10 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
+    "jsdoc": "^3.6.3",
     "prom-client": "^11.2.1",
+    "tsd-jsdoc": "^2.3.1",
+    "typescript-definition-tester": "0.0.6",
     "wrtc": "~0.3.7"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 'use strict'
+/**
+ * @module js-libp2p-webrtc-star
+ */
 
 const debug = require('debug')
 const log = debug('libp2p:webrtc-star')
@@ -25,8 +28,14 @@ const sioOptions = {
   transports: ['websocket'],
   'force new connection': true
 }
-
+/**
+ * @class
+ */
 class WebRTCStar {
+  /**
+   *
+   * @param {*} options
+   */
   constructor (options) {
     options = options || {}
 
@@ -57,6 +66,12 @@ class WebRTCStar {
     this._peerDiscovered = this._peerDiscovered.bind(this)
   }
 
+  /**
+   *
+   * @param {*} ma
+   * @param {object} options
+   * @param {function} callback
+   */
   dial (ma, options, callback) {
     if (typeof options === 'function') {
       callback = options
@@ -128,7 +143,11 @@ class WebRTCStar {
 
     return conn
   }
-
+  /**
+   *
+   * @param {object} options
+   * @param {function} handler 
+   */
   createListener (options, handler) {
     if (typeof options === 'function') {
       handler = options
@@ -228,7 +247,10 @@ class WebRTCStar {
     this.listenersRefs[multiaddr.toString()] = listener
     return listener
   }
-
+  /**
+   *
+   * @param {*} multiaddrs
+   */
   filter (multiaddrs) {
     if (!Array.isArray(multiaddrs)) {
       multiaddrs = [multiaddrs]
@@ -242,7 +264,10 @@ class WebRTCStar {
       return mafmt.WebRTCStar.matches(ma)
     })
   }
-
+  /**
+   *
+   * @param {*} maStr
+   */
   _peerDiscovered (maStr) {
     if (!this.discovery._isStarted) return
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,50 @@
+/**
+ * @module js-libp2p-webrtc-star
+ */
+declare module "js-libp2p-webrtc-star" {
+    /**
+     *
+     * @param {*} options
+     */
+    class WebRTCStar {
+        constructor(options: any);
+        /**
+         *
+         * @param {*} ma
+         * @param {object} options
+         * @param {function} callback
+         */
+        dial(ma: any, options: any, callback: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {object} options
+         * @param {function} handler
+         */
+        createListener(options: any, handler: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {*} multiaddrs
+         */
+        filter(multiaddrs: any): void;
+        /**
+         *
+         * @param {*} maStr
+         */
+        _peerDiscovered(maStr: any): void;
+    }
+}
+
+/**
+ * @module js-libp2p-webrtc-star/utils
+ */
+declare module "js-libp2p-webrtc-star/utils" {
+    /**
+     * @param {*} ma
+     */
+    function cleanUrlSIO(ma: any): void;
+    /**
+     * @param {*} maStr
+     */
+    function cleanMultiaddr(maStr: any): void;
+}
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,12 @@
 'use strict'
-
+/**
+ * @module js-libp2p-webrtc-star/utils
+ */
 const multiaddr = require('multiaddr')
 
+/**
+ * @param {*} ma
+ */
 function cleanUrlSIO (ma) {
   const maStrSplit = ma.toString().split('/')
   const tcpProto = ma.protos()[1].name
@@ -25,6 +30,9 @@ function cleanUrlSIO (ma) {
   }
 }
 
+/**
+ * @param {*} maStr 
+ */
 function cleanMultiaddr (maStr) {
   const legacy = '/libp2p-webrtc-star'
 


### PR DESCRIPTION
Generates Typescript Typings via JsDoc

* Adds typings to the js-libp2p-webrtc-star module
* Add typings generation to travis.yml
* Include typings test