### PR TITLE
docs: multiaddr should use p2p

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const multiaddr = require('multiaddr')
 const pipe = require('it-pipe')
 const { collect } = require('streaming-iterables')
 
-const addr = multiaddr('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+const addr = multiaddr('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
 
 const ws = new WStar({ upgrader })
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "interface-discovery": "~0.1.1",
     "interface-transport": "libp2p/interface-transport#chore/skip-abort-while-reading-for-webrtc",
     "prom-client": "^11.5.3",
+    "sinon": "^7.5.0",
     "wrtc": "~0.4.2"
   },
   "dependencies": {

--- a/test/sig-server.js
+++ b/test/sig-server.js
@@ -6,7 +6,6 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const io = require('socket.io-client')
-const parallel = require('async/parallel')
 const multiaddr = require('multiaddr')
 
 const sigServer = require('../src/sig-server')
@@ -210,18 +209,10 @@ describe('signalling', () => {
     }
   })
 
-  it('stop signalling server', () => {
-    parallel([
-      (cb) => {
-        c1.disconnect()
-        cb()
-      },
-      (cb) => {
-        c2.disconnect()
-        cb()
-      }
-    ], async () => {
-      await sigS.stop()
-    })
+  it('stop signalling server', async () => {
+    c1.disconnect()
+    c2.disconnect()
+
+    await sigS.stop()
   })
 })

--- a/test/transport/dial.js
+++ b/test/transport/dial.js
@@ -69,7 +69,7 @@ module.exports = (create) => {
 
     it('dial offline / non-exist()ent node on IPv4, check promise rejected', async function () {
       this.timeout(20 * 1000)
-      const maOffline = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/ABCD')
+      const maOffline = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2f')
 
       try {
         await ws1.dial(maOffline)


### PR DESCRIPTION
Updated documentation.

There was an issue with CI because we could not create invalid multiaddr anymore