### PR TITLE
fix: transport should not handle connection if upgradeInbound throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
-    "interface-discovery": "~0.1.1",
-    "interface-transport": "libp2p/interface-transport#chore/skip-abort-while-reading-for-webrtc",
+    "libp2p-interfaces": "libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
     "prom-client": "^11.5.3",
     "sinon": "^7.5.0",
     "wrtc": "~0.4.2"

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -4,8 +4,8 @@
 const wrtc = require('wrtc')
 
 const sinon = require('sinon')
-const testsTransport = require('interface-transport')
-const testsDiscovery = require('interface-discovery')
+const testsTransport = require('libp2p-interfaces/src/transport/tests')
+const testsDiscovery = require('libp2p-interfaces/src/peer-discovery/tests')
 const multiaddr = require('multiaddr')
 
 const WStar = require('../src')


### PR DESCRIPTION
Fixed per discussion on [libp2p/js-libp2p#523#discussion_r359997872](https://github.com/libp2p/js-libp2p/pull/523#discussion_r359997872)