### PR TITLE
fix: ensure remoteAddr is always set on inbound conns

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
-    "libp2p-interfaces": "libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
+    "libp2p-interfaces": "libp2p/js-interfaces#skip-abort-while-reading",
     "p-wait-for": "^3.1.0",
     "prom-client": "^11.5.3",
     "sinon": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,15 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-webrtc-star#readme",
   "devDependencies": {
-    "aegir": "^20.3.1",
+    "aegir": "^20.5.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "electron-webrtc": "~0.3.0",
     "libp2p-interfaces": "libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
+    "p-wait-for": "^3.1.0",
     "prom-client": "^11.5.3",
-    "sinon": "^7.5.0",
-    "wrtc": "~0.4.2"
+    "sinon": "^8.1.0",
+    "wrtc": "^0.4.3"
   },
   "dependencies": {
     "@hapi/hapi": "^18.4.0",

--- a/src/listener.js
+++ b/src/listener.js
@@ -106,9 +106,9 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
     return defer.promise
   }
 
-  listener.close = () => {
-    listener.__connections.forEach(maConn => maConn.close())
+  listener.close = async () => {
     listener.io && listener.io.emit('ss-leave')
+    await Promise.all(listener.__connections.map(maConn => maConn.close()))
     listener.emit('close')
   }
 

--- a/src/listener.js
+++ b/src/listener.js
@@ -70,7 +70,7 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
 
         if (!conn.remoteAddr) {
           try {
-            conn.remoteAddr = ma.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${conn.remotePeer.toString()}`)
+            conn.remoteAddr = ma.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${conn.remotePeer.toB58String()}`)
           } catch (err) {
             log.error('could not determine remote address', err)
           }

--- a/src/listener.js
+++ b/src/listener.js
@@ -69,8 +69,13 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
         }
 
         if (!conn.remoteAddr) {
-          conn.remoteAddr = ma.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${conn.remotePeer.toString()}`)
+          try {
+            conn.remoteAddr = ma.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${conn.remotePeer.toString()}`)
+          } catch (err) {
+            log.error('could not determine remote address', err)
+          }
         }
+
         log('inbound connection %s upgraded', maConn.remoteAddr)
 
         trackConn(listener, maConn)

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -10,7 +10,8 @@ const multiaddr = require('multiaddr')
 
 const WStar = require('../src')
 
-describe('interface-transport compliance', () => {
+describe('interface-transport compliance', function () {
+  this.timeout(10e3)
   testsTransport({
     setup ({ upgrader }) {
       const ws = new WStar({ upgrader, wrtc: wrtc })

--- a/test/transport/dial.js
+++ b/test/transport/dial.js
@@ -44,7 +44,10 @@ module.exports = (create) => {
     beforeEach(async () => {
       // first
       ws1 = create()
-      const listener1 = ws1.createListener((conn) => pipe(conn, conn))
+      const listener1 = ws1.createListener((conn) => {
+        expect(conn.remoteAddr).to.exist()
+        pipe(conn, conn)
+      })
 
       // second
       ws2 = create()


### PR DESCRIPTION
Inbound webrtc channels were being upgraded to Connections before the `connect` event was fired. When run in Node.js with wrtc this prevents us from getting the actual remoteAddress of the socket.

In the browser we cant get remoteAddress from the socket, so it is created by concatenating the signaling address with the remote peer id, and then set on the Connection before yielding it.

* I also updated the track connection test to avoid flakiness issues
* resolved some test flakiness issues via https://github.com/libp2p/js-interfaces/pull/21

- [x] Depends on https://github.com/libp2p/js-interfaces/pull/21