### PR TITLE
feat: improve listening address usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "err-code": "^2.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-utils": "^0.1.0",
-    "mafmt": "^7.0.0",
+    "mafmt": "multiformats/js-mafmt#fix/webrtc-star",
     "minimist": "^1.2.0",
     "multiaddr": "^7.1.0",
     "p-defer": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "err-code": "^2.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-utils": "^0.1.0",
-    "mafmt": "multiformats/js-mafmt#fix/webrtc-star",
+    "mafmt": "^7.0.1",
     "minimist": "^1.2.0",
     "multiaddr": "^7.1.0",
     "p-defer": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ class WebRTCStar {
         return false
       }
 
-      return mafmt.WebRTCStar.matches(ma)
+      return ma.protoCodes().includes(275)
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ const SimplePeer = require('simple-peer')
 const webrtcSupport = require('webrtcsupport')
 
 const multiaddr = require('multiaddr')
-const mafmt = require('mafmt')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const SimplePeer = require('simple-peer')
 const webrtcSupport = require('webrtcsupport')
 
 const multiaddr = require('multiaddr')
+const mafmt = require('mafmt')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 
@@ -218,7 +219,7 @@ class WebRTCStar {
         return false
       }
 
-      return ma.protoCodes().includes(275)
+      return mafmt.WebRTCStar.matches(ma)
     })
   }
 

--- a/src/listener.js
+++ b/src/listener.js
@@ -27,6 +27,10 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
   listener.listen = (ma) => {
     const defer = pDefer()
 
+    if (!ma.protoCodes().includes(CODE_P2P) && upgrader.localPeer) {
+      ma = ma.encapsulate(`/p2p/${upgrader.localPeer.toB58String()}`)
+    }
+
     WebRTCStar.maSelf = ma
     const sioUrl = cleanUrlSIO(ma)
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,17 +2,22 @@
 'use strict'
 
 const WStar = require('..')
+const PeerId = require('peer-id')
 
 const mockUpgrader = {
   upgradeInbound: maConn => maConn,
   upgradeOutbound: maConn => maConn
 }
 
-const create = () => {
-  return new WStar({ upgrader: mockUpgrader })
-}
+describe('browser RTC', async () => {
+  const localPeer = await PeerId.create()
+  mockUpgrader.localPeer = localPeer
+  const create = () => {
+    return new WStar({ upgrader: mockUpgrader })
+  }
 
-require('./transport/dial.js')(create)
-require('./transport/listen.js')(create)
-require('./transport/discovery.js')(create)
-require('./transport/filter.js')(create)
+  require('./transport/dial.js')(create)
+  require('./transport/listen.js')(create)
+  require('./transport/discovery.js')(create)
+  require('./transport/filter.js')(create)
+})

--- a/test/node.js
+++ b/test/node.js
@@ -4,6 +4,7 @@
 const wrtc = require('wrtc')
 const electronWebRTC = require('electron-webrtc')
 const WStar = require('..')
+const PeerId = require('peer-id')
 
 require('./sig-server.js')
 
@@ -12,7 +13,9 @@ const mockUpgrader = {
   upgradeOutbound: maConn => maConn
 }
 
-describe('transport: with wrtc', () => {
+describe('transport: with wrtc', async () => {
+  const localPeer = await PeerId.create()
+  mockUpgrader.localPeer = localPeer
   const create = () => {
     return new WStar({ upgrader: mockUpgrader, wrtc: wrtc })
   }

--- a/test/transport/filter.js
+++ b/test/transport/filter.js
@@ -29,7 +29,7 @@ module.exports = (create) => {
       ]
 
       const filtered = ws.filter(maArr)
-      expect(filtered.length).to.equal(9)
+      expect(filtered.length).to.equal(8)
     })
 
     it('filter a single addr for this transport', () => {

--- a/test/transport/filter.js
+++ b/test/transport/filter.js
@@ -29,7 +29,7 @@ module.exports = (create) => {
       ]
 
       const filtered = ws.filter(maArr)
-      expect(filtered.length).to.equal(7)
+      expect(filtered.length).to.equal(9)
     })
 
     it('filter a single addr for this transport', () => {

--- a/test/transport/listen.js
+++ b/test/transport/listen.js
@@ -12,7 +12,7 @@ module.exports = (create) => {
   describe('listen', () => {
     let ws
 
-    const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooooA')
+    const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
     before(() => {
       ws = create()
@@ -61,7 +61,8 @@ module.exports = (create) => {
       await listener.listen(ma)
 
       const addrs = listener.getAddrs()
-      expect(addrs[0]).to.deep.equal(ma)
+      const expectedAddr = ma.encapsulate(`/p2p/${ws._upgrader.localPeer.toB58String()}`)
+      expect(addrs[0]).to.deep.equal(expectedAddr)
 
       listener.close()
     })


### PR DESCRIPTION
Previously when listening on a webrtc-star multiaddr, you would also have to specify your PeerId. This PR makes it so that the PeerId will automatically be added to the multiaddrs returned from `listener.getAddrs()`.

This allows you to start libp2p with an address like `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star`, and it will automatically be updated with the peer id `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooooA` for advertising.

- [x] Depends on https://github.com/multiformats/js-mafmt/pull/47