### PR TITLE
fix: dont transform listening addrs

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -27,10 +27,6 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
   listener.listen = (ma) => {
     const defer = pDefer()
 
-    if (!ma.protoCodes().includes(CODE_P2P) && upgrader.localPeer) {
-      ma = ma.encapsulate(`/p2p/${upgrader.localPeer.toB58String()}`)
-    }
-
     WebRTCStar.maSelf = ma
     const sioUrl = cleanUrlSIO(ma)
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,16 +2,13 @@
 'use strict'
 
 const WStar = require('..')
-const PeerId = require('peer-id')
 
 const mockUpgrader = {
   upgradeInbound: maConn => maConn,
   upgradeOutbound: maConn => maConn
 }
 
-describe('browser RTC', async () => {
-  const localPeer = await PeerId.create()
-  mockUpgrader.localPeer = localPeer
+describe('browser RTC', () => {
   const create = () => {
     return new WStar({ upgrader: mockUpgrader })
   }

--- a/test/node.js
+++ b/test/node.js
@@ -4,7 +4,6 @@
 const wrtc = require('wrtc')
 const electronWebRTC = require('electron-webrtc')
 const WStar = require('..')
-const PeerId = require('peer-id')
 
 require('./sig-server.js')
 
@@ -13,9 +12,7 @@ const mockUpgrader = {
   upgradeOutbound: maConn => maConn
 }
 
-describe('transport: with wrtc', async () => {
-  const localPeer = await PeerId.create()
-  mockUpgrader.localPeer = localPeer
+describe('transport: with wrtc', () => {
   const create = () => {
     return new WStar({ upgrader: mockUpgrader, wrtc: wrtc })
   }

--- a/test/transport/listen.js
+++ b/test/transport/listen.js
@@ -57,12 +57,24 @@ module.exports = (create) => {
 
     it('getAddrs', async () => {
       const listener = ws.createListener(() => {})
+      const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
       await listener.listen(ma)
 
       const addrs = listener.getAddrs()
-      const expectedAddr = ma.encapsulate(`/p2p/${ws._upgrader.localPeer.toB58String()}`)
-      expect(addrs[0]).to.deep.equal(expectedAddr)
+      expect(addrs[0]).to.deep.equal(ma)
+
+      listener.close()
+    })
+
+    it('getAddrs with peer id', async () => {
+      const listener = ws.createListener(() => {})
+      const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooooA')
+
+      await listener.listen(ma)
+
+      const addrs = listener.getAddrs()
+      expect(addrs[0]).to.deep.equal(ma)
 
       listener.close()
     })


### PR DESCRIPTION
This fixes an unncessary change from #194. The transport
should not be modifying listen addresses. This was being done to overcome
an issue with mafmt not supporting all valid webrtc-star addresses,
however that was fixed and this hack wasn't reverted. This
reverts the hack to keep consistency with transport listening and
getAddrs behavior.