### PR TITLE
fix: signaling vs listening addrs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class WebRTCStar {
     assert(options.upgrader, 'An upgrader must be provided. See https://github.com/libp2p/interface-transport#upgrader.')
     this._upgrader = options.upgrader
 
-    this.maSelf = undefined
+    this._signallingAddr = undefined
 
     this.sioOptions = {
       transports: ['websocket'],
@@ -161,7 +161,7 @@ class WebRTCStar {
       channel.on('signal', (signal) => {
         sioClient.emit('ss-handshake', {
           intentId: intentId,
-          srcMultiaddr: this.maSelf.toString(),
+          srcMultiaddr: this._signallingAddr.toString(),
           dstMultiaddr: ma.toString(),
           signal: signal
         })

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const WStar = require('..')
+const PeerId = require('peer-id')
 
 const mockUpgrader = {
   upgradeInbound: maConn => maConn,
@@ -9,8 +10,15 @@ const mockUpgrader = {
 }
 
 describe('browser RTC', () => {
-  const create = () => {
-    return new WStar({ upgrader: mockUpgrader })
+  const create = async () => {
+    const localPeer = await PeerId.create()
+    return new WStar({
+      upgrader: {
+        upgradeInbound: maConn => maConn,
+        upgradeOutbound: maConn => maConn,
+        localPeer
+      }
+    })
   }
 
   require('./transport/dial.js')(create)

--- a/test/browser.js
+++ b/test/browser.js
@@ -4,11 +4,6 @@
 const WStar = require('..')
 const PeerId = require('peer-id')
 
-const mockUpgrader = {
-  upgradeInbound: maConn => maConn,
-  upgradeOutbound: maConn => maConn
-}
-
 describe('browser RTC', () => {
   const create = async () => {
     const localPeer = await PeerId.create()

--- a/test/node.js
+++ b/test/node.js
@@ -3,6 +3,7 @@
 
 const wrtc = require('wrtc')
 const electronWebRTC = require('electron-webrtc')
+const PeerId = require('peer-id')
 const WStar = require('..')
 
 require('./sig-server.js')
@@ -13,8 +14,16 @@ const mockUpgrader = {
 }
 
 describe('transport: with wrtc', () => {
-  const create = () => {
-    return new WStar({ upgrader: mockUpgrader, wrtc: wrtc })
+  const create = async () => {
+    const localPeer = await PeerId.create()
+    return new WStar({
+      upgrader: {
+        upgradeInbound: maConn => maConn,
+        upgradeOutbound: maConn => maConn,
+        localPeer
+      },
+      wrtc
+    })
   }
 
   require('./transport/dial.js')(create)

--- a/test/transport/dial.js
+++ b/test/transport/dial.js
@@ -19,38 +19,35 @@ module.exports = (create) => {
     let ma2
     let listener2
 
-    const maHSDNS = '/dns/star-signal.cloud.ipfs.team'
-    const maHSIP = '/ip4/188.166.203.82/tcp/20000'
-
-    const maLS = '/ip4/127.0.0.1/tcp/15555'
-    const maGen = (base, id) => multiaddr(`${base}/wss/p2p-webrtc-star/p2p/${id}`) // https
-    // const maGen = (base, id) => multiaddr(`${base}/ws/p2p-webrtc-star/ipfs/${id}`)
+    const maHSDNS = multiaddr('/dns/star-signal.cloud.ipfs.team/wss/p2p-webrtc-star')
+    const maHSIP = multiaddr('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star')
+    const maLS = multiaddr('/ip4/127.0.0.1/tcp/15555/wss/p2p-webrtc-star')
 
     if (process.env.WEBRTC_STAR_REMOTE_SIGNAL_DNS) {
       // test with deployed signalling server using DNS
       console.log('Using DNS:', maHSDNS)
-      ma1 = maGen(maHSDNS, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-      ma2 = maGen(maHSDNS, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2b')
+      ma1 = maHSDNS
+      ma2 = maHSDNS
     } else if (process.env.WEBRTC_STAR_REMOTE_SIGNAL_IP) {
       // test with deployed signalling server using IP
       console.log('Using IP:', maHSIP)
-      ma1 = maGen(maHSIP, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-      ma2 = maGen(maHSIP, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2b')
+      ma1 = maHSIP
+      ma2 = maHSIP
     } else {
-      ma1 = maGen(maLS, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-      ma2 = maGen(maLS, 'QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2b')
+      ma1 = maLS
+      ma2 = maLS
     }
 
     beforeEach(async () => {
       // first
-      ws1 = create()
+      ws1 = await create()
       const listener1 = ws1.createListener((conn) => {
         expect(conn.remoteAddr).to.exist()
         pipe(conn, conn)
       })
 
       // second
-      ws2 = create()
+      ws2 = await create()
       listener2 = ws2.createListener((conn) => pipe(conn, conn))
 
       await Promise.all([listener1.listen(ma1), listener2.listen(ma2)])
@@ -59,7 +56,7 @@ module.exports = (create) => {
     it('dial on IPv4, check promise', async function () {
       this.timeout(20 * 1000)
 
-      const conn = await ws1.dial(ma2)
+      const conn = await ws1.dial(ws2._signallingAddr)
       const data = Buffer.from('some data')
       const values = await pipe(
         [data],

--- a/test/transport/discovery.js
+++ b/test/transport/discovery.js
@@ -11,42 +11,33 @@ const multiaddr = require('multiaddr')
 module.exports = (create) => {
   describe('peer discovery', () => {
     let ws1
-    let ws1Listener
-    const base = (id) => {
-      return `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/${id}`
-    }
-    const ma1 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3A'))
-
     let ws2
-    const ma2 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3B'))
-
     let ws3
-    const ma3 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3C'))
-
     let ws4
-    const ma4 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3D'))
+    let ws1Listener
+    const signallerAddr = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
     it('listen on the first', async () => {
-      ws1 = create()
+      ws1 = await create()
       ws1Listener = ws1.createListener(() => { })
       ws1.discovery.start()
 
-      await ws1Listener.listen(ma1)
+      await ws1Listener.listen(signallerAddr)
     })
 
     it('listen on the second, discover the first', async () => {
-      ws2 = create()
+      ws2 = await create()
       const listener = ws2.createListener(() => { })
       ws2.discovery.start()
 
       const p = new Promise((resolve) => {
         ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ma2)).to.equal(true)
+          expect(peerInfo.multiaddrs.has(ws2._signallingAddr)).to.equal(true)
           resolve()
         })
       })
 
-      listener.listen(ma2)
+      listener.listen(signallerAddr)
       await p
     })
 
@@ -66,11 +57,11 @@ module.exports = (create) => {
         })
       })
 
-      ws3 = create()
+      ws3 = await create()
       const listener = ws3.createListener(() => { })
       ws3.discovery.start()
 
-      await listener.listen(ma3)
+      await listener.listen(signallerAddr)
       await p
     })
 
@@ -89,11 +80,11 @@ module.exports = (create) => {
       })
 
       ws1.discovery.stop()
-      ws4 = create()
+      ws4 = await create()
       const listener = ws4.createListener(() => { })
       ws4.discovery.start()
 
-      await listener.listen(ma4)
+      await listener.listen(signallerAddr)
       await p
     })
   })

--- a/test/transport/filter.js
+++ b/test/transport/filter.js
@@ -10,8 +10,8 @@ const multiaddr = require('multiaddr')
 
 module.exports = (create) => {
   describe('filter', () => {
-    it('filters non valid webrtc-star multiaddrs', () => {
-      const ws = create()
+    it('filters non valid webrtc-star multiaddrs', async () => {
+      const ws = await create()
 
       const maArr = [
         multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1'),
@@ -32,8 +32,8 @@ module.exports = (create) => {
       expect(filtered.length).to.equal(8)
     })
 
-    it('filter a single addr for this transport', () => {
-      const ws = create()
+    it('filter a single addr for this transport', async () => {
+      const ws = await create()
       const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1')
 
       const filtered = ws.filter(ma)

--- a/test/transport/listen.js
+++ b/test/transport/listen.js
@@ -14,8 +14,8 @@ module.exports = (create) => {
 
     const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
-    before(() => {
-      ws = create()
+    before(async () => {
+      ws = await create()
     })
 
     it('listen, check for promise', async () => {

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -14,6 +14,7 @@ const SERVER_PORT = 13580
 module.exports = (create) => {
   describe('reconnect to signaling server', () => {
     let sigS
+    const signallerAddr = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
     const base = (id) => {
       return `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/${id}`
@@ -36,27 +37,27 @@ module.exports = (create) => {
     })
 
     it('listen on the first', async () => {
-      ws1 = create()
+      ws1 = await create()
 
       const listener = ws1.createListener(() => {})
       ws1.discovery.start()
 
-      await listener.listen(ma1)
+      await listener.listen(signallerAddr)
     })
 
     it('listen on the second, discover the first', async () => {
-      ws2 = create()
+      ws2 = await create()
 
       const p = new Promise((resolve) => {
         ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ma2)).to.equal(true)
+          expect(peerInfo.multiaddrs.has(ws2._signallingAddr)).to.equal(true)
           resolve()
         })
       })
 
       const listener = ws2.createListener(() => {})
 
-      await listener.listen(ma2)
+      await listener.listen(signallerAddr)
       await p
     })
 
@@ -73,14 +74,14 @@ module.exports = (create) => {
     })
 
     it('listen on the third, first discovers it', async () => {
-      ws3 = create()
+      ws3 = await create()
 
       const listener = ws3.createListener(() => {})
-      await listener.listen(ma3)
+      await listener.listen(signallerAddr)
 
       await new Promise((resolve) => {
         ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ma3)).to.equal(true)
+          expect(peerInfo.multiaddrs.has(ws3._signallingAddr)).to.equal(true)
           resolve()
         })
       })

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -14,19 +14,10 @@ const SERVER_PORT = 13580
 module.exports = (create) => {
   describe('reconnect to signaling server', () => {
     let sigS
-    const signallerAddr = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
-
-    const base = (id) => {
-      return `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/${id}`
-    }
-
     let ws1
     let ws2
     let ws3
-
-    const ma1 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3A'))
-    const ma2 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3B'))
-    const ma3 = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3C'))
+    const signallerAddr = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
     before(async () => {
       sigS = await sigServer.start({ port: SERVER_PORT })


### PR DESCRIPTION
- Listening multiaddrs should be returned unmodified
- multiaddrs announced over signaling must include the peer id

These were being treated as the same multiaddr, which causes problems when you are using a listening multiaddr that doesn't contain a peer id `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star`, which is a more convenient way of specifying a listening multiaddr.

This PR makes these two things separate, listening vs announce multiaddrs.

### Test correction
The tests weren't doing a good job of validating connections. In many of the tests the same multiaddr was being used (with the exact same id), which would actually result in a peer dialing itself, and not the other peer. This PR also corrects that, which will help catch multiaddr issues like the ones this PR fixes.