### PR TITLE
fix: ensure dial is rejected with an Error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ class WebRTCStar {
       // are clueless as to why.
       sioClient.on('ws-handshake', (offer) => {
         if (offer.intentId === intentId && offer.err) {
-          reject(offer.err)
+          reject(errcode(offer.err instanceof Error ? offer.err : new Error(offer.err), 'ERR_HANDSHAKE_FAILED'))
         }
 
         if (offer.intentId !== intentId || !offer.answer) {

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ class WebRTCStar {
       // are clueless as to why.
       sioClient.on('ws-handshake', (offer) => {
         if (offer.intentId === intentId && offer.err) {
-          reject(errcode(offer.err instanceof Error ? offer.err : new Error(offer.err), 'ERR_HANDSHAKE_FAILED'))
+          reject(errcode(offer.err instanceof Error ? offer.err : new Error(offer.err), 'ERR_SIGNALLING_FAILED'))
         }
 
         if (offer.intentId !== intentId || !offer.answer) {

--- a/test/transport/dial.js
+++ b/test/transport/dial.js
@@ -75,7 +75,7 @@ module.exports = (create) => {
         await ws1.dial(maOffline)
       } catch (err) {
         expect(err).to.be.an.instanceOf(Error)
-        expect(err).to.have.property('code', 'ERR_HANDSHAKE_FAILED')
+        expect(err).to.have.property('code', 'ERR_SIGNALLING_FAILED')
         return
       }
 

--- a/test/transport/dial.js
+++ b/test/transport/dial.js
@@ -74,7 +74,8 @@ module.exports = (create) => {
       try {
         await ws1.dial(maOffline)
       } catch (err) {
-        expect(err).to.exist()
+        expect(err).to.be.an.instanceOf(Error)
+        expect(err).to.have.property('code', 'ERR_HANDSHAKE_FAILED')
         return
       }
 


### PR DESCRIPTION
`offer.err` is returned as a string, convert it to an Error.

I encountered this trying to connect to a signalling server that was not running, the error was thrown as a string.

I pulled the error code out of thin air, there might be a more appropriate one to use.