### PR TITLE
feat: support dash case parameters

### DIFF
--- a/src/sig-server/bin.js
+++ b/src/sig-server/bin.js
@@ -3,13 +3,20 @@
 
 'use strict'
 
+// Usage: $0 [--host <host>] [--port <port>] [--disable-metrics]
+
 const signalling = require('./index')
-const argv = require('minimist')(process.argv.slice(2))
+const minimist = require('minimist')
+const argv = minimist(process.argv.slice(2), {
+  p: 'port',
+  h: 'host',
+  'disable-metrics': 'disableMetrics'
+})
 
 ;(async () => {
   const server = await signalling.start({
-    port: argv.port || argv.p || process.env.PORT || 9090,
-    host: argv.host || argv.h || process.env.HOST || '0.0.0.0',
+    port: argv.port || process.env.PORT || 9090,
+    host: argv.host || process.env.HOST || '0.0.0.0',
     metrics: !(argv.disableMetrics || process.env.DISABLE_METRICS)
   })
 

--- a/src/sig-server/bin.js
+++ b/src/sig-server/bin.js
@@ -8,9 +8,11 @@
 const signalling = require('./index')
 const minimist = require('minimist')
 const argv = minimist(process.argv.slice(2), {
-  p: 'port',
-  h: 'host',
-  'disable-metrics': 'disableMetrics'
+  alias: {
+    p: 'port',
+    h: 'host',
+    'disable-metrics': 'disableMetrics'
+  }
 })
 
 ;(async () => {


### PR DESCRIPTION
Per discussion on [libp2p/js-libp2p-stardust#26](https://github.com/libp2p/js-libp2p-stardust/pull/26) this adds support for dash case parameters in the server binary runner with alias.
