### PR TITLE
chore: peer-discovery not using peer-info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ const webrtcSupport = require('webrtcsupport')
 const multiaddr = require('multiaddr')
 const mafmt = require('mafmt')
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 
 const { CODE_CIRCUIT } = require('./constants')
 const createListener = require('./listener')
@@ -233,9 +232,11 @@ class WebRTCStar {
 
     const ma = multiaddr(maStr)
     const peerId = PeerId.createFromB58String(ma.getPeerId())
-    const peerInfo = new PeerInfo(peerId)
-    peerInfo.multiaddrs.add(ma)
-    this.discovery.emit('peer', peerInfo)
+
+    this.discovery.emit('peer', {
+      id: peerId,
+      multiaddrs: [ma]
+    })
   }
 }
 

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -40,6 +40,8 @@ describe('interface-transport compliance', function () {
 })
 
 describe('interface-discovery compliance', () => {
+  let intervalId
+
   testsDiscovery({
     setup () {
       const mockUpgrader = {
@@ -47,8 +49,14 @@ describe('interface-discovery compliance', () => {
         upgradeOutbound: maConn => maConn
       }
       const ws = new WStar({ upgrader: mockUpgrader, wrtc: wrtc })
+      const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d'
+
+      intervalId = setInterval(() => ws._peerDiscovered(maStr), 1000)
 
       return ws.discovery
+    },
+    teardown () {
+      clearInterval(intervalId)
     }
   })
 })

--- a/test/transport/discovery.js
+++ b/test/transport/discovery.js
@@ -31,8 +31,8 @@ module.exports = (create) => {
       ws2.discovery.start()
 
       const p = new Promise((resolve) => {
-        ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ws2._signallingAddr)).to.equal(true)
+        ws1.discovery.once('peer', ({ multiaddrs }) => {
+          expect(multiaddrs.some((m) => m.equals(ws2._signallingAddr))).to.equal(true)
           resolve()
         })
       })

--- a/test/transport/reconnect.node.js
+++ b/test/transport/reconnect.node.js
@@ -40,8 +40,8 @@ module.exports = (create) => {
       ws2 = await create()
 
       const p = new Promise((resolve) => {
-        ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ws2._signallingAddr)).to.equal(true)
+        ws1.discovery.once('peer', ({ multiaddrs }) => {
+          expect(multiaddrs.some((m) => m.equals(ws2._signallingAddr))).to.equal(true)
           resolve()
         })
       })
@@ -71,8 +71,8 @@ module.exports = (create) => {
       await listener.listen(signallerAddr)
 
       await new Promise((resolve) => {
-        ws1.discovery.once('peer', (peerInfo) => {
-          expect(peerInfo.multiaddrs.has(ws3._signallingAddr)).to.equal(true)
+        ws1.discovery.once('peer', ({ multiaddrs }) => {
+          expect(multiaddrs.some((m) => m.equals(ws3._signallingAddr))).to.equal(true)
           resolve()
         })
       })


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR changes the `peer-discovery` interface to emit an object containing an `id` property and a `multiaddrs` property.

BREAKING CHANGE: peer event emits an object with id and multiaddr instead of a peer-info

Needs:

- [x] libp2p-interface branch rebased with PR below
- [x] [libp2p/js-libp2p-interfaces#41](https://github.com/libp2p/js-libp2p-interfaces/pull/41)