### PR TITLE
fix: add error handler for incoming connections

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,6 @@ class WebRTCStar {
       }
 
       const done = (err) => {
-        channel.removeListener('error', onError)
         channel.removeListener('timeout', onTimeout)
         channel.removeListener('connect', onConnect)
         options.signal && options.signal.removeEventListener('abort', onAbort)
@@ -153,10 +152,12 @@ class WebRTCStar {
         err ? reject(err) : resolve(channel)
       }
 
-      channel.once('error', onError)
+      channel.on('error', onError)
       channel.once('timeout', onTimeout)
       channel.once('connect', onConnect)
-      channel.on('close', () => channel.destroy())
+      channel.on('close', () => {
+        channel.removeListener('error', onError)
+      })
       options.signal && options.signal.addEventListener('abort', onAbort)
 
       channel.on('signal', (signal) => {

--- a/src/listener.js
+++ b/src/listener.js
@@ -55,6 +55,15 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
 
       const channel = new SimplePeer(spOptions)
 
+      const onError = (err) => {
+        log.error('incoming connectioned errored', err)
+      }
+
+      channel.on('error', onError)
+      channel.once('close', (...args) => {
+        channel.removeListener('error', onError)
+      })
+
       channel.once('signal', (signal) => {
         offer.signal = signal
         offer.answer = true

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -23,7 +23,7 @@ const toWebrtcMultiaddr = (address, port) => {
 }
 
 // Convert a socket into a MultiaddrConnection
-// https://github.com/libp2p/interface-transport#multiaddrconnection
+// https://github.com/libp2p/js-libp2p-interfaces/tree/master/src/transport#multiaddrconnection
 module.exports = (socket, options = {}) => {
   const { sink, source } = toIterable.duplex(socket)
 


### PR DESCRIPTION
This fixes https://github.com/libp2p/js-libp2p/issues/662

This should also be cherry-picked to `0.17.x`