### PR TITLE
fix: do not signal if channel destroyed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ class WebRTCStar {
           reject(errcode(offer.err instanceof Error ? offer.err : new Error(offer.err), 'ERR_SIGNALLING_FAILED'))
         }
 
-        if (offer.intentId !== intentId || !offer.answer) {
+        if (offer.intentId !== intentId || !offer.answer || channel.destroyed) {
           return
         }
 


### PR DESCRIPTION
Fixes #225 

This should also be cherry-picked to 0.17.x