### PR TITLE
fix: use relaxed webrtc check

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "ipfs-utils": "^2.3.0",
+    "ipfs-utils": "^2.4.0",
     "it-pipe": "^1.0.1",
     "libp2p-utils": "^0.2.0",
     "libp2p-webrtc-peer": "^10.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const withIs = require('class-is')
 
 const { AbortError } = require('abortable-iterator')
 const SimplePeer = require('libp2p-webrtc-peer')
-const { supportsWebRTC: webrtcSupport } = require('ipfs-utils/src/supports')
+const { supportsWebRTCDataChannels: webrtcSupport } = require('ipfs-utils/src/supports')
 
 const multiaddr = require('multiaddr')
 const mafmt = require('mafmt')


### PR DESCRIPTION
`ipfs-utils@2.4.0` adds a `supportsWebRTCDataChannels` property which is true if the current environment supports `RTCPeerConnection`s.
    
Since we only use WebRTC data channels and not `getUserMedia`, switch our check over to `supportsWebRTCDataChannels` when deciding if WebRTC is supported or not.