### PR TITLE
chore: update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
-  - '12'
+  - 'lts/*'
+  - 'node'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -60,13 +60,13 @@
     "wrtc": "^0.4.3"
   },
   "dependencies": {
-    "@hapi/hapi": "^18.4.0",
-    "@hapi/inert": "^5.2.2",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/inert": "^6.0.2",
     "abortable-iterator": "^3.0.0",
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "ipfs-utils": "^2.4.0",
+    "ipfs-utils": "^3.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-utils": "^0.2.0",
     "libp2p-webrtc-peer": "^10.0.1",


### PR DESCRIPTION
Updates Hapi to the latest version

BREAKING CHANGES:

- Hapi has dropped support for node < 12