### PR TITLE
chore: update socket.io to 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "libp2p-interfaces": "^0.8.1",
     "p-wait-for": "^3.1.0",
     "sinon": "^9.2.0",
+    "socket.io-client": "^2.3.0",
     "uint8arrays": "^2.0.5",
     "wrtc": "^0.4.6"
   },
@@ -78,7 +79,8 @@
     "peer-id": "^0.14.2",
     "prom-client": "^13.0.0",
     "socket.io": "^2.3.0",
-    "socket.io-client": "^2.3.0",
+    "socket.io-next": "npm:socket.io@^3.0.4",
+    "socket.io-client-next": "npm:socket.io-client@^3.0.4",
     "stream-to-it": "^0.2.2",
     "streaming-iterables": "^5.0.3"
   },

--- a/src/listener.js
+++ b/src/listener.js
@@ -7,7 +7,7 @@ log.error = debug('libp2p:webrtc-star:listener:error')
 
 const multiaddr = require('multiaddr')
 
-const io = require('socket.io-client')
+const io = require('socket.io-client-next')
 const SimplePeer = require('libp2p-webrtc-peer')
 const pDefer = require('p-defer')
 
@@ -17,7 +17,8 @@ const { CODE_P2P } = require('./constants')
 
 const sioOptions = {
   transports: ['websocket'],
-  'force new connection': true
+  'force new connection': true,
+  path: '/socket.io-next/' // This should be removed when socket.io@2 support is removed
 }
 
 module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {

--- a/src/sig-server/index.js
+++ b/src/sig-server/index.js
@@ -26,7 +26,13 @@ module.exports = {
 
     log('signaling server has started on: ' + http.info.uri)
 
-    http.peers = require('./routes-ws')(http, options.metrics).peers
+    const peers = require('./routes-ws')(http, options.metrics).peers
+    const next = require('./routes-ws/next')(http, options.metrics).peers
+
+    http.peers = () => ({
+      ...peers(),
+      ...next()
+    })
 
     http.route({
       method: 'GET',

--- a/src/sig-server/routes-ws/next.js
+++ b/src/sig-server/routes-ws/next.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const config = require('../config')
+const log = config.log
+const socketIO = require('socket.io-next')
+const client = require('prom-client')
+
+const fake = {
+  gauge: {
+    set: () => {}
+  },
+  counter: {
+    inc: () => {}
+  }
+}
+
+module.exports = (http, hasMetrics) => {
+  const io = socketIO(http.listener, {
+    path: '/socket.io-next/' // This should be removed when socket.io@2 support is removed
+  })
+
+  io.on('connection', handle)
+
+  const peers = {}
+
+  const peersMetric = hasMetrics ? new client.Gauge({ name: 'webrtc_star_next_peers', help: 'peers online now' }) : fake.gauge
+  const dialsSuccessTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_dials_total_success', help: 'sucessfully completed dials since server started' }) : fake.counter
+  const dialsFailureTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_dials_total_failure', help: 'failed dials since server started' }) : fake.counter
+  const dialsTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_dials_total', help: 'all dials since server started' }) : fake.counter
+  const joinsSuccessTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_joins_total_success', help: 'sucessfully completed joins since server started' }) : fake.counter
+  const joinsFailureTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_joins_total_failure', help: 'failed joins since server started' }) : fake.counter
+  const joinsTotal = hasMetrics ? new client.Counter({ name: 'webrtc_star_next_joins_total', help: 'all joins since server started' }) : fake.counter
+
+  const refreshMetrics = () => peersMetric.set(Object.keys(peers).length)
+
+  this.peers = () => {
+    return peers
+  }
+
+  function safeEmit (addr, event, arg) {
+    const peer = peers[addr]
+    if (!peer) {
+      log('trying to emit %s but peer is gone', event)
+      return
+    }
+
+    peer.emit(event, arg)
+  }
+
+  function handle (socket) {
+    socket.on('ss-join', join.bind(socket))
+    socket.on('ss-leave', leave.bind(socket))
+    socket.on('disconnect', disconnect.bind(socket)) // socket.io own event
+    socket.on('ss-handshake', forwardHandshake)
+  }
+
+  // join this signaling server network
+  function join (multiaddr) {
+    joinsTotal.inc()
+    if (!multiaddr) { return joinsFailureTotal.inc() }
+    const socket = peers[multiaddr] = this // socket
+    let refreshInterval = setInterval(sendPeers, config.refreshPeerListIntervalMS)
+
+    socket.once('ss-leave', stopSendingPeers)
+    socket.once('disconnect', stopSendingPeers)
+
+    sendPeers()
+
+    function sendPeers () {
+      Object.keys(peers).forEach((mh) => {
+        if (mh === multiaddr) {
+          return
+        }
+        safeEmit(mh, 'ws-peer', multiaddr)
+      })
+    }
+
+    function stopSendingPeers () {
+      if (refreshInterval) {
+        clearInterval(refreshInterval)
+        refreshInterval = null
+      }
+    }
+
+    joinsSuccessTotal.inc()
+    refreshMetrics()
+  }
+
+  function leave (multiaddr) {
+    if (!multiaddr) { return }
+    if (peers[multiaddr]) {
+      delete peers[multiaddr]
+      refreshMetrics()
+    }
+  }
+
+  function disconnect () {
+    Object.keys(peers).forEach((mh) => {
+      if (peers[mh].id === this.id) {
+        delete peers[mh]
+      }
+      refreshMetrics()
+    })
+  }
+
+  // forward an WebRTC offer to another peer
+  function forwardHandshake (offer) {
+    dialsTotal.inc()
+    if (offer == null || typeof offer !== 'object' || !offer.srcMultiaddr || !offer.dstMultiaddr) { return dialsFailureTotal.inc() }
+    if (offer.answer) {
+      dialsSuccessTotal.inc()
+      safeEmit(offer.srcMultiaddr, 'ws-handshake', offer)
+    } else {
+      if (peers[offer.dstMultiaddr]) {
+        safeEmit(offer.dstMultiaddr, 'ws-handshake', offer)
+      } else {
+        dialsFailureTotal.inc()
+        offer.err = 'peer is not available'
+        safeEmit(offer.srcMultiaddr, 'ws-handshake', offer)
+      }
+    }
+  }
+
+  return this
+}

--- a/test/node.js
+++ b/test/node.js
@@ -6,6 +6,7 @@ const electronWebRTC = require('electron-webrtc')
 const PeerId = require('peer-id')
 const WStar = require('..')
 
+require('./sig-server-next.js')
 require('./sig-server.js')
 
 const mockUpgrader = {

--- a/test/sig-server-next.js
+++ b/test/sig-server-next.js
@@ -1,0 +1,216 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('aegir/utils/chai')
+const io = require('socket.io-client-next')
+const multiaddr = require('multiaddr')
+
+const sigServer = require('../src/sig-server')
+
+describe('signalling', () => {
+  const sioOptions = {
+    transports: ['websocket'],
+    'force new connection': true,
+    path: '/socket.io-next/' // This should be removed when socket.io@2 support is removed
+  }
+
+  let sioUrl
+  let sigS
+  let c1
+  let c2
+  let c3
+  let c4
+
+  const base = (id) => {
+    return `/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/${id}`
+  }
+
+  const c1mh = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1'))
+  const c2mh = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo2'))
+  const c3mh = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo3'))
+  const c4mh = multiaddr(base('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'))
+
+  it('start and stop signalling server (default port)', async () => {
+    const server = await sigServer.start()
+
+    expect(server.info.port).to.equal(13579)
+    expect(server.info.protocol).to.equal('http')
+    expect(server.info.address).to.equal('0.0.0.0')
+
+    await server.stop()
+  })
+
+  it('start and stop signalling server (default port) and spam it with invalid requests', async () => {
+    const server = await sigServer.start()
+
+    expect(server.info.port).to.equal(13579)
+    expect(server.info.protocol).to.equal('http')
+    expect(server.info.address).to.equal('0.0.0.0')
+
+    const cl = io.connect(server.info.uri, { path: '/socket.io-next/' }) // This should be removed when socket.io@2 support is removed
+    cl.on('connect', async () => {
+      cl.emit('ss-handshake', null)
+      cl.emit('ss-handshake', 1)
+      cl.emit('ss-handshake', [1, 2, 3])
+      cl.emit('ss-handshake', {})
+
+      await server.stop()
+    })
+  })
+
+  it('start and stop signalling server (custom port)', async () => {
+    const options = {
+      port: 12345
+    }
+
+    const server = await sigServer.start(options)
+
+    expect(server.info.port).to.equal(12345)
+    expect(server.info.protocol).to.equal('http')
+    expect(server.info.address).to.equal('0.0.0.0')
+    await server.stop()
+  })
+
+  it('start signalling server for client tests', async () => {
+    const options = {
+      port: 12345
+    }
+
+    const server = await sigServer.start(options)
+
+    expect(server.info.port).to.equal(12345)
+    expect(server.info.protocol).to.equal('http')
+    expect(server.info.address).to.equal('0.0.0.0')
+    sioUrl = server.info.uri
+    sigS = server
+  })
+
+  it('zero peers', () => {
+    expect(Object.keys(sigS.peers).length).to.equal(0)
+  })
+
+  it('connect one client', (done) => {
+    c1 = io.connect(sioUrl, sioOptions)
+    c1.on('connect', done)
+  })
+
+  it('connect three more clients', (done) => {
+    let count = 0
+
+    c2 = io.connect(sioUrl, sioOptions)
+    c3 = io.connect(sioUrl, sioOptions)
+    c4 = io.connect(sioUrl, sioOptions)
+
+    c2.on('connect', connected)
+    c3.on('connect', connected)
+    c4.on('connect', connected)
+
+    function connected () {
+      if (++count === 3) { done() }
+    }
+  })
+
+  it('ss-join first client', (done) => {
+    c1.emit('ss-join', c1mh.toString())
+    setTimeout(() => {
+      expect(Object.keys(sigS.peers()).length).to.equal(1)
+      done()
+    }, 10)
+  })
+
+  it('ss-join and ss-leave second client', (done) => {
+    c2.emit('ss-join', c2mh.toString())
+    setTimeout(() => {
+      expect(Object.keys(sigS.peers()).length).to.equal(2)
+      c2.emit('ss-leave', c2mh.toString())
+      setTimeout(() => {
+        expect(Object.keys(sigS.peers()).length).to.equal(1)
+        done()
+      }, 10)
+    }, 10)
+  })
+
+  it('ss-join and disconnect third client', (done) => {
+    c3.emit('ss-join', c3mh.toString())
+    setTimeout(() => {
+      expect(Object.keys(sigS.peers()).length).to.equal(2)
+      c3.disconnect()
+      setTimeout(() => {
+        expect(Object.keys(sigS.peers()).length).to.equal(1)
+        done()
+      }, 10)
+    }, 10)
+  })
+
+  it('ss-join the fourth', (done) => {
+    c1.once('ws-peer', (multiaddr) => {
+      expect(multiaddr).to.equal(c4mh.toString())
+      expect(Object.keys(sigS.peers()).length).to.equal(2)
+      done()
+    })
+    c4.emit('ss-join', c4mh.toString())
+  })
+
+  it('c1 handshake c4', (done) => {
+    c4.once('ws-handshake', (offer) => {
+      offer.answer = true
+      c4.emit('ss-handshake', offer)
+    })
+
+    c1.once('ws-handshake', (offer) => {
+      expect(offer.err).to.not.exist()
+      expect(offer.answer).to.equal(true)
+      done()
+    })
+
+    c1.emit('ss-handshake', {
+      srcMultiaddr: c1mh.toString(),
+      dstMultiaddr: c4mh.toString()
+    })
+  })
+
+  it('c1 handshake c2 fail (does not exist() anymore)', (done) => {
+    c1.once('ws-handshake', (offer) => {
+      expect(offer.err).to.exist()
+      done()
+    })
+
+    c1.emit('ss-handshake', {
+      srcMultiaddr: c1mh.toString(),
+      dstMultiaddr: c2mh.toString()
+    })
+  })
+
+  it('disconnects every client', (done) => {
+    [c1, c2, c3, c4].forEach((c) => c.disconnect())
+    done()
+  })
+
+  it('emits ws-peer every 10 seconds', function (done) {
+    this.timeout(50000)
+    let peersEmitted = 0
+
+    c1 = io.connect(sioUrl, sioOptions)
+    c2 = io.connect(sioUrl, sioOptions)
+    c1.emit('ss-join', 'c1')
+    c2.emit('ss-join', 'c2')
+
+    c1.on('ws-peer', (p) => {
+      expect(p).to.be.equal('c2')
+      check()
+    })
+
+    function check () {
+      if (++peersEmitted === 2) {
+        done()
+      }
+    }
+  })
+
+  it('stop signalling server', async () => {
+    c1.disconnect()
+    c2.disconnect()
+
+    await sigS.stop()
+  })
+})


### PR DESCRIPTION
This PR aims to update the `socket.io` dependency to its version 3. This update was done in #285  but reverted per #287 

We will need to support socket.io 2 clients for the time being and this PR takes into account the recommendation from the socket.io migration guide in: https://socket.io/docs/v3/migrating-from-2-x-to-3-0/index.html#How-to-upgrade-an-existing-production-deployment

Shortly, this PR leverages the package aliases feature of npm, in order to have both versions running in parallel. Per the migration guide recommendations, this PR uses the `next` naming for referencing the new version. This will need further changes once we remove support for socket.io 2. We will need to support both `/socket-io` and `/socket-io-next` using the 3x version.
This results of our need to support the path `/socket-io`, which cannot be modified for now.