### PR TITLE
feat: adds transportTag to maConn

### DIFF
--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -63,6 +63,8 @@ module.exports = (socket, options = {}) => {
 
     timeline: { open: Date.now() },
 
+    transportTag: 'WebRTCStar',
+
     close () {
       if (socket.destroyed) return
 


### PR DESCRIPTION
Adds `transportTag` parameter to `maConn` passed to upgrader to create Connection.

To adhere to https://github.com/libp2p/js-libp2p/pull/854 to solve https://github.com/libp2p/js-libp2p/issues/838