### PR TITLE
fix: add error event listener to event emitter

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -38,6 +38,8 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
       WebRTCStar._signallingAddr = ma
     }
 
+    listener.on('error', () => defer.reject())
+
     const sioUrl = cleanUrlSIO(ma)
 
     log('Dialing to Signalling Server on: ' + sioUrl)

--- a/test/transport/listen.js
+++ b/test/transport/listen.js
@@ -52,6 +52,14 @@ module.exports = (create) => {
       // TODO IPv6 not supported yet
     })
 
+    it('should throw an error if it cannot listen on the given multiaddr', async () => {
+      const listener = ws.createListener(() => { })
+      const ma = multiaddr('/ip4/127.0.0.1/tcp/15554/ws/p2p-webrtc-star')
+
+      await expect(listener.listen(ma))
+        .to.eventually.be.rejected()
+    })
+
     it('getAddrs', async () => {
       const listener = ws.createListener(() => {})
       const ma = multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')


### PR DESCRIPTION
Adds an error event listener and reject the promise.