### PR TITLE
chore: update to new peer-id and libp2p-crypto

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - uses: actions/cache@v2
         id: cache
         env:
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - uses: actions/cache@v2
         id: cache
         env:
@@ -145,7 +145,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - uses: actions/cache@v2
         id: cache
         env:
@@ -177,7 +177,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - uses: actions/cache@v2
         id: cache
         env:

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -37,7 +37,7 @@
     "aegir": "^36.0.2",
     "electron-webrtc": "~0.3.0",
     "it-all": "^1.0.5",
-    "libp2p-interfaces-compliance-tests": "^1.1.1",
+    "libp2p-interfaces-compliance-tests": "^2.0.1",
     "libp2p-webrtc-star-signalling-server": "^0.1.1",
     "p-wait-for": "^3.1.0",
     "sinon": "^12.0.1",
@@ -57,7 +57,7 @@
     "mafmt": "^10.0.0",
     "multiaddr": "^10.0.0",
     "p-defer": "^3.0.0",
-    "peer-id": "^0.15.0",
+    "peer-id": "^0.16.0",
     "socket.io-client": "^4.1.2",
     "stream-to-it": "^0.2.2"
   },


### PR DESCRIPTION
BREAKING CHANGE: requires node 15+