### PR TITLE
fix: pass abort signal to upgrader

### DIFF
--- a/packages/transport/src/index.js
+++ b/packages/transport/src/index.js
@@ -75,7 +75,7 @@ class WebRTCStar {
     const rawConn = await this._connect(ma, options)
     const maConn = toConnection(rawConn, { remoteAddr: ma, signal: options.signal })
     log('new outbound connection %s', maConn.remoteAddr)
-    const conn = await this._upgrader.upgradeOutbound(maConn)
+    const conn = await this._upgrader.upgradeOutbound(maConn, options)
     log('outbound connection %s upgraded', maConn.remoteAddr)
     return conn
   }

--- a/packages/transport/src/listener.js
+++ b/packages/transport/src/listener.js
@@ -111,7 +111,7 @@ module.exports = ({ handler, upgrader }, WebRTCStar, options = {}) => {
 
         let conn
         try {
-          conn = await upgrader.upgradeInbound(maConn)
+          conn = await upgrader.upgradeInbound(maConn, options)
         } catch (err) {
           log.error('inbound connection failed to upgrade', err)
           return maConn.close()


### PR DESCRIPTION
In order to abort in-progress dials and not leak memory, the abort signal must be passed to the upgrader in order for it to be passed on to mss and noise.

Refs: https://github.com/libp2p/js-libp2p/pull/1072