### PR TITLE
fix: fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,7 @@
 FROM node:lts-alpine as node
 
-FROM node as builder
-
-# Install deps
-RUN apk add build-base python3 libressl-dev ca-certificates
-
-# Setup directories for the `node` user
-RUN mkdir -p /home/node/app/webrtc-star/node_modules && chown -R node:node /home/node/app/webrtc-star
-
-WORKDIR /home/node/app/webrtc-star
-
-# Install node modules
-COPY packages/webrtc-star-signalling-server/package.json ./
 # Switch to the node user for installation
-RUN npm install --production
-
-# Copy over source files under the node user
-COPY ./packages/webrtc-star-signalling-server/bin ./bin
-COPY ./packages/webrtc-star-signalling-server/src ./src
-COPY ./packages/webrtc-star-signalling-server/dist ./dist
-COPY ./packages/webrtc-star-signalling-server/README.md ./
-
-# Start from a clean node image
-FROM node as server
-
-# Prepare the working dir
-RUN mkdir -p /home/node/app/webrtc-star/node_modules && chown -R node:node /home/node/app/webrtc-star
-WORKDIR /home/node/app/webrtc-star
-
-# Copy installed and compiled modules w/o build dependencies
-COPY --from=builder --chown=node:node /home/node/app/webrtc-star /home/node/app/webrtc-star
+RUN npm install -g @libp2p/webrtc-star-signalling-server
 
 # webrtc-star defaults to 9090
 EXPOSE 9090
@@ -38,5 +10,4 @@ EXPOSE 9090
 #   --port=9090 --host=0.0.0.0 --disableMetrics=false
 # Server logging can be enabled via the DEBUG environment variable:
 #   DEBUG=signalling-server,signalling-server:error
-RUN chmod +x bin/index.js
-CMD [ "node", "bin/index.js"]
+CMD [ "webrtc-star"]

--- a/packages/webrtc-star-signalling-server/bin/index.js
+++ b/packages/webrtc-star-signalling-server/bin/index.js
@@ -5,6 +5,10 @@
 
 import { sigServer } from '../dist/src/index.js'
 import minimist from 'minimist'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const info = require('../package.json')
 
 const argv = minimist(process.argv.slice(2), {
   alias: {
@@ -21,6 +25,7 @@ const argv = minimist(process.argv.slice(2), {
     metrics: !(argv.disableMetrics || process.env.DISABLE_METRICS)
   })
 
+  console.log(`${info.name}@${info.version}`)
   console.log('Listening on:', server.info.uri)
 
   process.on('SIGINT', async () => {


### PR DESCRIPTION
Instead of building from source on every push, build when a GH release is created and use the built version from npm.

The GH hook in this repo has been updated accordingly.