### PR TITLE
chore: enable node testing

### DIFF
--- a/packages/webrtc-star-transport/.aegir.cjs
+++ b/packages/webrtc-star-transport/.aegir.cjs
@@ -1,5 +1,9 @@
 'use strict'
 
+// TODO: Temporary fix per wrtc issue
+// https://github.com/node-webrtc/node-webrtc/issues/636#issuecomment-774171409
+process.on('beforeExit', (code) => process.exit(code))
+
 let firstRun = true
 
 /** @type {import('aegir').PartialOptions} */

--- a/packages/webrtc-star-transport/package.json
+++ b/packages/webrtc-star-transport/package.json
@@ -126,6 +126,7 @@
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f \"./dist/test/**/*.spec.js\"",
+    "test:node": "npm run test -- -t node -f ./dist/test/node.js ",
     "test:chrome": "npm run test -- -t browser -f ./dist/test/browser.js ",
     "test:firefox": "npm run test -- -t browser -- --browser firefox -f ./dist/test/browser.js",
     "test:dns": "WEBRTC_STAR_REMOTE_SIGNAL_DNS=1 aegir test -t browser",

--- a/packages/webrtc-star-transport/src/index.ts
+++ b/packages/webrtc-star-transport/src/index.ts
@@ -105,7 +105,7 @@ export class WebRTCStar implements Transport, Initializable {
   }
 
   get [Symbol.toStringTag] () {
-    return this.constructor.name
+    return '@libp2p/webrtc-star'
   }
 
   init (components: Components) {

--- a/packages/webrtc-star-transport/test/node.ts
+++ b/packages/webrtc-star-transport/test/node.ts
@@ -15,6 +15,10 @@ import trackTests from './transport/track.js'
 import reconnectTests from './transport/reconnect.node.js'
 import { Components } from '@libp2p/interfaces/components'
 
+// TODO: Temporary fix per wrtc issue
+// https://github.com/node-webrtc/node-webrtc/issues/636#issuecomment-774171409
+process.on('beforeExit', (code) => process.exit(code))
+
 describe('transport: with wrtc', () => {
   const create = async () => {
     const peerId = await createEd25519PeerId()


### PR DESCRIPTION
Registers shutdown hook to work around double-free that causes segfaults in recent node versions.