### PR TITLE
fix: Readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 ## Structure
 
 * [`/packages/signalling-server`](./packages/webrtc-star-signalling-server) A signalling server to allow peer discovery
-* [`/packages/transport`](./packages/transport) The webrtc-star transport
+* [`/packages/transport`](./packages/webrtc-star-transport) The webrtc-star transport
+* [`/packages/protocol`](./packages/webrtc-star-protocol) Type definitions used by other packages
 
 ## Contribute
 


### PR DESCRIPTION
`transport` link was incorrect. Also took the opportunity to add a
reference to the `protocol` package.