### PR TITLE
feat: pass through middleware config, noDefaultRoute option (proposal)

### DIFF
--- a/packages/webrtc-star-signalling-server/src/index.ts
+++ b/packages/webrtc-star-signalling-server/src/index.ts
@@ -1,4 +1,5 @@
 import { Server } from '@hapi/hapi'
+import type { ServerOptions } from '@hapi/hapi'
 import Inert from '@hapi/inert'
 
 import { config } from './config.js'
@@ -19,6 +20,8 @@ interface Options {
   host?: string
   metrics?: boolean
   refreshPeerListIntervalMS?: number
+  noDefaultRoute?: boolean
+  hapi?: ServerOptions
 }
 
 export interface SigServer extends Server {
@@ -33,6 +36,7 @@ export async function sigServer (options: Options = {}) {
 
   const http: SigServer = Object.assign(new Server({
     ...config.hapi.options,
+    ...options.hapi ?? {},
     port,
     host
   }), {
@@ -57,13 +61,15 @@ export async function sigServer (options: Options = {}) {
 
   log('signaling server has started on: ' + http.info.uri)
 
-  http.route({
-    method: 'GET',
-    path: '/',
-    handler: (request, reply) => reply.file(path.join(currentDir, 'index.html'), {
-      confine: false
+  if (options.noDefaultRoute == null) {
+    http.route({
+      method: 'GET',
+      path: '/',
+      handler: (_, reply) => reply.file(path.join(currentDir, 'index.html'), {
+        confine: false
+      })
     })
-  })
+  }
 
   if (options.metrics === true) {
     log('enabling metrics')

--- a/packages/webrtc-star-signalling-server/tsconfig.json
+++ b/packages/webrtc-star-signalling-server/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "emitDeclarationOnly": false,
-    "module": "ES2020"
+    "module": "ES2020",
+    "moduleResolution": "node"
   },
   "include": [
     "src",

--- a/packages/webrtc-star-transport/.aegir.js
+++ b/packages/webrtc-star-transport/.aegir.js
@@ -7,6 +7,7 @@ let firstRun = true
 /** @type {import('aegir').PartialOptions} */
 export default {
   test: {
+    target: ["node", "browser", "electron-main"],
     async before () {
       const { sigServer } = await import('@libp2p/webrtc-star-signalling-server')
 


### PR DESCRIPTION
this is the proposal

as a user of webrtc-star transport i want finer control over signalling server middleware to be able to:
1. host web app which uses that signalling server
2. provide CORS configuration for other web apps to make them able to communicate with this signalling server

____
i had to explicitly set test runtimes in aegir config in transport package because somehow it was trying to run tests within webworker runtime which does not (yet?) support WebRTC. i have no explanation for that. i use `npm test` command to run all tests