### PR TITLE
fix: do not close connections when sigserver goes away

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs
 *.log
 
 coverage
+.coverage
 
 # Runtime data
 pids

--- a/packages/webrtc-star-signalling-server/src/index.ts
+++ b/packages/webrtc-star-signalling-server/src/index.ts
@@ -18,6 +18,7 @@ interface Options {
   port?: number
   host?: string
   metrics?: boolean
+  refreshPeerListIntervalMS?: number
 }
 
 export interface SigServer extends Server {
@@ -36,7 +37,11 @@ export async function sigServer (options: Options = {}) {
     host
   }), {
     peers,
-    io: socketServer(peers, options.metrics ?? false)
+    io: socketServer(
+      peers,
+      options.metrics ?? false,
+      options.refreshPeerListIntervalMS ?? config.refreshPeerListIntervalMS
+    )
   })
 
   http.io.attach(http.listener, {

--- a/packages/webrtc-star-signalling-server/src/socket-server.ts
+++ b/packages/webrtc-star-signalling-server/src/socket-server.ts
@@ -14,7 +14,7 @@ const fake = {
   }
 }
 
-export function socketServer (peers: Map<string, WebRTCStarSocket>, hasMetrics: boolean) {
+export function socketServer (peers: Map<string, WebRTCStarSocket>, hasMetrics: boolean, refreshPeerListIntervalMS: number) {
   const io = new Server({
     allowEIO3: true // allow socket.io v2 clients to connect
   })
@@ -60,7 +60,7 @@ export function socketServer (peers: Map<string, WebRTCStarSocket>, hasMetrics: 
       socket.once('ss-leave', stopSendingPeers)
       socket.once('disconnect', stopSendingPeers)
 
-      let refreshInterval: NodeJS.Timer | undefined = setInterval(sendPeers, config.refreshPeerListIntervalMS)
+      let refreshInterval: NodeJS.Timer | undefined = setInterval(sendPeers, refreshPeerListIntervalMS)
       sendPeers()
 
       function sendPeers () {

--- a/packages/webrtc-star-transport/package.json
+++ b/packages/webrtc-star-transport/package.json
@@ -167,6 +167,7 @@
     "electron-webrtc": "~0.3.0",
     "it-all": "^1.0.5",
     "it-pipe": "^2.0.3",
+    "it-pushable": "^3.0.0",
     "p-event": "^5.0.1",
     "p-wait-for": "^4.1.0",
     "sinon": "^14.0.0",

--- a/packages/webrtc-star-transport/src/index.ts
+++ b/packages/webrtc-star-transport/src/index.ts
@@ -76,6 +76,8 @@ export interface SignalServerServerEvents {
   'listening': CustomEvent
   'peer': CustomEvent<string>
   'connection': CustomEvent<Connection>
+  'disconnect': CustomEvent
+  'reconnect': CustomEvent
 }
 
 export interface SignalServer extends EventEmitter<SignalServerServerEvents> {

--- a/packages/webrtc-star-transport/src/listener.ts
+++ b/packages/webrtc-star-transport/src/listener.ts
@@ -75,14 +75,17 @@ class SigServer extends EventEmitter<SignalServerServerEvents> implements Signal
     })
     this.socket.on('connect', () => {
       this.socket.emit('ss-join', signallingAddr.toString())
-      this.dispatchEvent(new CustomEvent('reconnect'))
+
+      if (previouslyConnected) {
+        this.dispatchEvent(new CustomEvent('reconnect'))
+      }
     })
     this.socket.once('connect', () => {
       // make sure we can reconnect in future
       previouslyConnected = true
       this.dispatchEvent(new CustomEvent('listening'))
     })
-    this.socket.on('disconnect', (reason, description) => {
+    this.socket.on('disconnect', () => {
       this.dispatchEvent(new CustomEvent('disconnect'))
     })
   }

--- a/packages/webrtc-star-transport/src/listener.ts
+++ b/packages/webrtc-star-transport/src/listener.ts
@@ -1,6 +1,6 @@
 import { logger } from '@libp2p/logger'
 import errCode from 'err-code'
-import { connect } from 'socket.io-client'
+import { connect, ManagerOptions, SocketOptions } from 'socket.io-client'
 import pDefer from 'p-defer'
 import { WebRTCReceiver } from '@libp2p/webrtc-peer'
 import { toMultiaddrConnection } from './socket-to-conn.js'
@@ -17,9 +17,8 @@ import { EventEmitter, CustomEvent } from '@libp2p/interfaces/events'
 
 const log = logger('libp2p:webrtc-star:listener')
 
-const sioOptions = {
+const sioOptions: Partial<ManagerOptions & SocketOptions> = {
   transports: ['websocket'],
-  'force new connection': true,
   path: '/socket.io-next/' // This should be removed when socket.io@2 support is removed
 }
 
@@ -49,26 +48,37 @@ class SigServer extends EventEmitter<SignalServerServerEvents> implements Signal
 
     this.handleWsHandshake = this.handleWsHandshake.bind(this)
 
-    this.socket.once('connect_error', (err) => {
-      this.dispatchEvent(new CustomEvent('error', {
-        detail: err
-      }))
-    })
-    this.socket.once('error', (err: Error) => {
-      this.dispatchEvent(new CustomEvent('error', {
-        detail: err
-      }))
-    })
+    let previouslyConnected = false
 
+    this.socket.on('connect_error', (err: Error) => {
+      if (!previouslyConnected) {
+        this.dispatchEvent(new CustomEvent('error', {
+          detail: err
+        }))
+      }
+    })
+    this.socket.on('error', (err: Error) => {
+      this.dispatchEvent(new CustomEvent('error', {
+        detail: err
+      }))
+    })
     this.socket.on('ws-handshake', this.handleWsHandshake)
     this.socket.on('ws-peer', (maStr) => {
       this.dispatchEvent(new CustomEvent('peer', {
         detail: maStr
       }))
     })
-    this.socket.on('connect', () => this.socket.emit('ss-join', signallingAddr.toString()))
+    this.socket.on('connect', () => {
+      this.socket.emit('ss-join', signallingAddr.toString())
+      this.dispatchEvent(new CustomEvent('reconnect'))
+    })
     this.socket.once('connect', () => {
+      // make sure we can reconnect in future
+      previouslyConnected = true
       this.dispatchEvent(new CustomEvent('listening'))
+    })
+    this.socket.on('disconnect', (reason, description) => {
+      this.dispatchEvent(new CustomEvent('disconnect'))
     })
   }
 
@@ -242,7 +252,7 @@ class WebRTCListener extends EventEmitter<ListenerEvents> implements Listener {
       signallingAddr = ma
     }
 
-    this.signallingUrl = cleanUrlSIO(ma)
+    const signallingUrl = this.signallingUrl = cleanUrlSIO(ma)
 
     log('connecting to signalling server on: %s', this.signallingUrl)
     const server: SignalServer = new SigServer(this.signallingUrl, signallingAddr, this.upgrader, this.handler, this.options.channelOptions)
@@ -277,6 +287,15 @@ class WebRTCListener extends EventEmitter<ListenerEvents> implements Listener {
       this.dispatchEvent(new CustomEvent('connection', {
         detail: conn
       }))
+    })
+    server.addEventListener('disconnect', () => {
+      // Ensure we error if we try to dial while we are disconnected from
+      // the signalling server
+      this.transport.sigServers.delete(signallingUrl)
+    })
+    server.addEventListener('reconnect', () => {
+      // We can dial via the signalling server again
+      this.transport.sigServers.set(signallingUrl, server)
     })
 
     // Store listen and signal reference addresses

--- a/packages/webrtc-star-transport/src/listener.ts
+++ b/packages/webrtc-star-transport/src/listener.ts
@@ -74,7 +74,7 @@ class SigServer extends EventEmitter<SignalServerServerEvents> implements Signal
       }))
     })
     this.socket.on('connect', () => {
-      this.socket.emit('ss-join', signallingAddr.toString())
+      this.socket.emit('ss-join', this.signallingAddr.toString())
 
       if (previouslyConnected) {
         this.dispatchEvent(new CustomEvent('reconnect'))

--- a/packages/webrtc-star-transport/src/listener.ts
+++ b/packages/webrtc-star-transport/src/listener.ts
@@ -50,12 +50,17 @@ class SigServer extends EventEmitter<SignalServerServerEvents> implements Signal
 
     let previouslyConnected = false
 
-    this.socket.on('connect_error', (err: Error) => {
-      if (!previouslyConnected) {
-        this.dispatchEvent(new CustomEvent('error', {
-          detail: err
-        }))
+    this.socket.on('connect_error', err => {
+      // @ts-expect-error `.type` is missing from the types
+      if (previouslyConnected && err.type === 'TransportError') {
+        // if we've had an open connection before, and this is a
+        // transport error, let socket.io's reconnect logic take over
+        return
       }
+
+      this.dispatchEvent(new CustomEvent('error', {
+        detail: err
+      }))
     })
     this.socket.on('error', (err: Error) => {
       this.dispatchEvent(new CustomEvent('error', {

--- a/packages/webrtc-star-transport/test/browser.ts
+++ b/packages/webrtc-star-transport/test/browser.ts
@@ -7,13 +7,23 @@ import listenTests from './transport/listen.js'
 import discoveryTests from './transport/discovery.js'
 import filterTests from './transport/filter.js'
 import { Components } from '@libp2p/components'
+import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 
 describe('browser RTC', () => {
   const create = async () => {
+    const peerId = await createEd25519PeerId()
     const ws = new WebRTCStar()
-    ws.init(new Components({ peerId: await createEd25519PeerId() }))
+    ws.init(new Components({ peerId }))
 
-    return ws
+    const registrar = mockRegistrar()
+    const upgrader = mockUpgrader({ registrar })
+
+    return {
+      peerId,
+      transport: ws,
+      registrar,
+      upgrader
+    }
   }
 
   dialTests(create)

--- a/packages/webrtc-star-transport/test/index.ts
+++ b/packages/webrtc-star-transport/test/index.ts
@@ -1,0 +1,11 @@
+import type { Registrar } from '@libp2p/interface-registrar'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import type { Upgrader } from '@libp2p/interface-transport'
+import type { WebRTCStar } from '../src'
+
+export interface PeerTransport {
+  peerId: PeerId
+  transport: WebRTCStar
+  upgrader: Upgrader
+  registrar: Registrar
+}

--- a/packages/webrtc-star-transport/test/node.ts
+++ b/packages/webrtc-star-transport/test/node.ts
@@ -14,20 +14,30 @@ import multipleSignalServersTests from './transport/multiple-signal-servers.js'
 import trackTests from './transport/track.js'
 import reconnectTests from './transport/reconnect.node.js'
 import { Components } from '@libp2p/components'
+import type { PeerTransport } from './index.js'
+import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 
 // TODO: Temporary fix per wrtc issue
 // https://github.com/node-webrtc/node-webrtc/issues/636#issuecomment-774171409
 process.on('beforeExit', (code) => process.exit(code))
 
 describe('transport: with wrtc', () => {
-  const create = async () => {
+  const create = async (): Promise<PeerTransport> => {
     const peerId = await createEd25519PeerId()
     const ws = new WebRTCStar({
       wrtc
     })
     ws.init(new Components({ peerId }))
 
-    return ws
+    const registrar = mockRegistrar()
+    const upgrader = mockUpgrader({ registrar })
+
+    return {
+      peerId,
+      transport: ws,
+      registrar,
+      upgrader
+    }
   }
 
   dialTests(create)
@@ -48,7 +58,15 @@ describe.skip('transport: with electron-webrtc', () => {
     })
     ws.init(new Components({ peerId }))
 
-    return ws
+    const registrar = mockRegistrar()
+    const upgrader = mockUpgrader({ registrar })
+
+    return {
+      peerId,
+      transport: ws,
+      registrar,
+      upgrader
+    }
   }
 
   dialTests(create)

--- a/packages/webrtc-star-transport/test/transport/dial.ts
+++ b/packages/webrtc-star-transport/test/transport/dial.ts
@@ -12,8 +12,9 @@ import type { Listener, Upgrader } from '@libp2p/interface-transport'
 import pWaitFor from 'p-wait-for'
 import type { HandshakeSignal } from '@libp2p/webrtc-star-protocol'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
+import type { PeerTransport } from '../index.js'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('dial', () => {
     let ws1: WebRTCStar
     let ws2: WebRTCStar
@@ -56,7 +57,7 @@ export default (create: () => Promise<WebRTCStar>) => {
       })
 
       // first
-      ws1 = await create()
+      ;({ transport: ws1 } = await create())
       listener1 = ws1.createListener({
         upgrader,
         handler: (conn) => {
@@ -70,7 +71,7 @@ export default (create: () => Promise<WebRTCStar>) => {
       })
 
       // second
-      ws2 = await create()
+      ;({ transport: ws2 } = await create())
       listener2 = ws2.createListener({
         upgrader,
         handler: (conn) => {

--- a/packages/webrtc-star-transport/test/transport/discovery.ts
+++ b/packages/webrtc-star-transport/test/transport/discovery.ts
@@ -7,8 +7,9 @@ import { cleanUrlSIO } from '../../src/utils.js'
 import type { WebRTCStar } from '../../src/index.js'
 import type { Listener } from '@libp2p/interface-transport'
 import { mockUpgrader } from '@libp2p/interface-mocks'
+import type { PeerTransport } from '../index.js'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('peer discovery', () => {
     let ws1: WebRTCStar
     let ws2: WebRTCStar
@@ -24,7 +25,7 @@ export default (create: () => Promise<WebRTCStar>) => {
     })
 
     it('listen on the first', async () => {
-      ws1 = await create()
+      ({ transport: ws1 } = await create())
       ws1Listener = ws1.createListener({ upgrader: mockUpgrader() })
       await ws1.discovery.start()
 
@@ -32,7 +33,7 @@ export default (create: () => Promise<WebRTCStar>) => {
     })
 
     it('listen on the second, discover the first', async () => {
-      ws2 = await create()
+      ({ transport: ws2 } = await create())
       const listener = ws2.createListener({ upgrader: mockUpgrader() })
       await ws2.discovery.start()
 
@@ -63,7 +64,7 @@ export default (create: () => Promise<WebRTCStar>) => {
         once: true
       })
 
-      ws3 = await create()
+      ;({ transport: ws3 } = await create())
       const listener = ws3.createListener({ upgrader: mockUpgrader() })
       await ws3.discovery.start()
 
@@ -91,7 +92,7 @@ export default (create: () => Promise<WebRTCStar>) => {
       })
 
       void ws1.discovery.stop()
-      ws4 = await create()
+      ;({ transport: ws4 } = await create())
       const listener = ws4.createListener({ upgrader: mockUpgrader() })
       void ws4.discovery.start()
 

--- a/packages/webrtc-star-transport/test/transport/filter.ts
+++ b/packages/webrtc-star-transport/test/transport/filter.ts
@@ -2,12 +2,12 @@
 
 import { expect } from 'aegir/chai'
 import { Multiaddr } from '@multiformats/multiaddr'
-import type { WebRTCStar } from '../../src/index.js'
+import type { PeerTransport } from '../index.js'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('filter', () => {
     it('filters non valid webrtc-star multiaddrs', async () => {
-      const ws = await create()
+      const peer = await create()
 
       const maArr = [
         new Multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1'),
@@ -24,15 +24,15 @@ export default (create: () => Promise<WebRTCStar>) => {
           '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1')
       ]
 
-      const filtered = ws.filter(maArr)
+      const filtered = peer.transport.filter(maArr)
       expect(filtered.length).to.equal(8)
     })
 
     it('filter a single addr for this transport', async () => {
-      const ws = await create()
+      const peer = await create()
       const ma = new Multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1')
 
-      const filtered = ws.filter([ma])
+      const filtered = peer.transport.filter([ma])
       expect(filtered.length).to.equal(1)
     })
   })

--- a/packages/webrtc-star-transport/test/transport/listen.ts
+++ b/packages/webrtc-star-transport/test/transport/listen.ts
@@ -5,14 +5,15 @@ import { Multiaddr } from '@multiformats/multiaddr'
 import { pEvent } from 'p-event'
 import type { WebRTCStar } from '../../src/index.js'
 import { mockUpgrader } from '@libp2p/interface-mocks'
+import type { PeerTransport } from '../index.js'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('listen', () => {
     let ws: WebRTCStar
     const ma = new Multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 
     before(async () => {
-      ws = await create()
+      ({ transport: ws } = await create())
     })
 
     it('listen, check for promise', async () => {

--- a/packages/webrtc-star-transport/test/transport/multiple-signal-servers.ts
+++ b/packages/webrtc-star-transport/test/transport/multiple-signal-servers.ts
@@ -6,20 +6,21 @@ import { pipe } from 'it-pipe'
 import type { WebRTCStar } from '../../src/index.js'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 import type { Upgrader } from '@libp2p/interface-transport'
+import type { PeerTransport } from '../index.js'
 
 const ma1 = new Multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
 const ma2 = new Multiaddr('/ip4/127.0.0.1/tcp/15556/ws/p2p-webrtc-star')
 const protocol = '/echo/1.0.0'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('multiple signal servers', () => {
     let ws1: WebRTCStar
     let ws2: WebRTCStar
     let upgrader: Upgrader
 
     beforeEach(async () => {
-      ws1 = await create()
-      ws2 = await create()
+      ({ transport: ws1 } = await create())
+      ;({ transport: ws2 } = await create())
 
       const registrar = mockRegistrar()
       void registrar.handle(protocol, ({ stream }) => {

--- a/packages/webrtc-star-transport/test/transport/reconnect.node.ts
+++ b/packages/webrtc-star-transport/test/transport/reconnect.node.ts
@@ -128,7 +128,7 @@ export default (create: () => Promise<PeerTransport>) => {
       await sigS.stop()
     })
 
-    it.only('does not drop connections when the signalling server disconnects', async () => {
+    it('does not drop connections when the signalling server disconnects', async () => {
       // returns a promise that resolves when peer1 has discovered peer2 and peer3
       async function discoverPeers () {
         const peer2Discovered = pDefer()

--- a/packages/webrtc-star-transport/test/transport/reconnect.node.ts
+++ b/packages/webrtc-star-transport/test/transport/reconnect.node.ts
@@ -3,15 +3,21 @@
 import { expect } from 'aegir/chai'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { sigServer } from '@libp2p/webrtc-star-signalling-server'
-import { pEvent } from 'p-event'
 import type { SigServer } from '@libp2p/webrtc-star-signalling-server'
-import type { WebRTCStar } from '../../src/index.js'
 import type { Listener } from '@libp2p/interface-transport'
 import { mockUpgrader } from '@libp2p/interface-mocks'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { pushable } from 'it-pushable'
+import pWaitFor from 'p-wait-for'
+import type { PeerTransport } from '../index.js'
+import pDefer from 'p-defer'
+import delay from 'delay'
+import type { WebRTCStar } from '../../src/index.js'
+import { pEvent } from 'p-event'
 
 const SERVER_PORT = 13580
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('reconnect to signaling server', () => {
     let sigS: SigServer
     let ws1: WebRTCStar
@@ -20,15 +26,13 @@ export default (create: () => Promise<WebRTCStar>) => {
     let listener1: Listener
     let listener2: Listener
     let listener3: Listener
-    const signallerAddr = new Multiaddr('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star')
+    const signallerAddr = new Multiaddr(`/ip4/127.0.0.1/tcp/${SERVER_PORT}/ws/p2p-webrtc-star`)
 
     before(async () => {
       sigS = await sigServer({ port: SERVER_PORT })
     })
 
     after(async () => {
-      await sigS.stop()
-
       if (listener1 != null) {
         await listener1.close()
       }
@@ -40,10 +44,12 @@ export default (create: () => Promise<WebRTCStar>) => {
       if (listener3 != null) {
         await listener3.close()
       }
+
+      await sigS.stop()
     })
 
     it('listen on the first', async () => {
-      ws1 = await create()
+      ({ transport: ws1 } = await create())
 
       listener1 = ws1.createListener({ upgrader: mockUpgrader() })
       await ws1.discovery.start()
@@ -52,7 +58,7 @@ export default (create: () => Promise<WebRTCStar>) => {
     })
 
     it('listen on the second, discover the first', async () => {
-      ws2 = await create()
+      ({ transport: ws2 } = await create())
 
       listener2 = ws2.createListener({ upgrader: mockUpgrader() })
 
@@ -78,7 +84,7 @@ export default (create: () => Promise<WebRTCStar>) => {
     })
 
     it('listen on the third, first discovers it', async () => {
-      ws3 = await create()
+      ({ transport: ws3 } = await create())
 
       listener3 = ws3.createListener({ upgrader: mockUpgrader() })
       await listener3.listen(signallerAddr)
@@ -89,6 +95,159 @@ export default (create: () => Promise<WebRTCStar>) => {
       const [sigRefs] = ws3.sigServers.values()
 
       expect(multiaddrs.some((m) => m.equals(sigRefs.signallingAddr))).to.equal(true)
+    })
+  })
+
+  describe('can close signaling server without dropping existing connections or streams', () => {
+    let sigS: SigServer
+    let listener1: Listener
+    let listener2: Listener
+    let listener3: Listener
+    const signallerAddr = new Multiaddr(`/ip4/127.0.0.1/tcp/${SERVER_PORT}/ws/p2p-webrtc-star`)
+
+    before(async () => {
+      sigS = await sigServer({
+        port: SERVER_PORT,
+        refreshPeerListIntervalMS: 100
+      })
+    })
+
+    after(async () => {
+      if (listener1 != null) {
+        await listener1.close()
+      }
+
+      if (listener2 != null) {
+        await listener2.close()
+      }
+
+      if (listener3 != null) {
+        await listener3.close()
+      }
+
+      await sigS.stop()
+    })
+
+    it('does not drop connections when the signalling server disconnects', async () => {
+      // returns a promise that resolves when peer1 has discovered peer2 and peer3
+      async function discoverPeers () {
+        const peer2Discovered = pDefer()
+        const peer3Discovered = pDefer()
+
+        peer1.transport.discovery.addEventListener('peer', event => {
+          const discoveredPeer = event.detail.id
+
+          if (discoveredPeer.equals(peer2.peerId)) {
+            peer2Discovered.resolve()
+          }
+
+          if (discoveredPeer.equals(peer3.peerId)) {
+            peer3Discovered.resolve()
+          }
+        })
+
+        await Promise.all([
+          peer2Discovered.promise,
+          peer3Discovered.promise
+        ])
+      }
+
+      const protocol = '/test/protocol/1.0.0'
+      const received: Uint8Array[] = []
+
+      // listen on the first
+      const peer1 = await create()
+      listener1 = peer1.transport.createListener({ upgrader: mockUpgrader() })
+      await peer1.transport.discovery.start()
+      await listener1.listen(signallerAddr)
+
+      // wait for peer discovery
+      let discover = discoverPeers()
+
+      // create the second
+      const peer2 = await create()
+      // collect messages sent from peer 1 -> peer 2
+      void peer2.registrar.handle(protocol, ({ stream }) => {
+        void Promise.resolve().then(async () => {
+          for await (const data of stream.source) {
+            received.push(data)
+          }
+        })
+      })
+      listener2 = peer2.transport.createListener({ upgrader: peer2.upgrader })
+      await listener2.listen(signallerAddr)
+
+      const peer3 = await create()
+      listener3 = peer3.transport.createListener({ upgrader: peer3.upgrader })
+      await listener3.listen(signallerAddr)
+
+      // wait for peer discovery
+      await discover
+
+      // ws1 dial ws2
+      const connection = await peer1.transport.dial(signallerAddr.encapsulate(`/p2p/${peer2.peerId.toString()}`), {
+        upgrader: peer1.upgrader
+      })
+      const stream = await connection.newStream(protocol)
+
+      // send messages from peer 1 -> peer 2
+      const sender = pushable()
+      void stream.sink(sender)
+
+      expect(received).to.be.empty()
+
+      sender.push(uint8ArrayFromString('message 1'))
+
+      await pWaitFor(() => {
+        return received.length === 1
+      })
+
+      // stop the signalling server
+      await sigS.stop({ timeout: 1 })
+
+      // wait for all connections to close
+      await delay(1000)
+
+      // send another message
+      sender.push(uint8ArrayFromString('message 2'))
+
+      // should still receive the message
+      await pWaitFor(() => {
+        return received.length === 2
+      })
+
+      // should not have closed connection or stream
+      expect(connection.stat.timeline.close).to.not.be.ok()
+      expect(stream.stat.timeline.close).to.not.be.ok()
+
+      // fail to dial a peer through the signalling server
+      await expect(peer1.transport.dial(signallerAddr.encapsulate(`/p2p/${peer3.peerId.toString()}`), {
+        upgrader: peer1.upgrader
+      })).to.eventually.be.rejected()
+
+      // setup promise that resolves after we rediscover peers
+      discover = discoverPeers()
+
+      // start the signalling server again
+      await sigS.start()
+
+      // wait to reconnect to the server
+      await delay(1000)
+
+      // send a final message
+      sender.push(uint8ArrayFromString('message 3'))
+
+      await pWaitFor(() => {
+        return received.length === 3
+      })
+
+      // wait for peer rediscovery
+      await discover
+
+      // can dial again
+      await expect(peer1.transport.dial(signallerAddr.encapsulate(`/p2p/${peer3.peerId.toString()}`), {
+        upgrader: peer1.upgrader
+      })).to.eventually.be.ok()
     })
   })
 }

--- a/packages/webrtc-star-transport/test/transport/reconnect.node.ts
+++ b/packages/webrtc-star-transport/test/transport/reconnect.node.ts
@@ -128,7 +128,7 @@ export default (create: () => Promise<PeerTransport>) => {
       await sigS.stop()
     })
 
-    it('does not drop connections when the signalling server disconnects', async () => {
+    it.only('does not drop connections when the signalling server disconnects', async () => {
       // returns a promise that resolves when peer1 has discovered peer2 and peer3
       async function discoverPeers () {
         const peer2Discovered = pDefer()

--- a/packages/webrtc-star-transport/test/transport/track.ts
+++ b/packages/webrtc-star-transport/test/transport/track.ts
@@ -9,10 +9,11 @@ import { cleanUrlSIO } from '../../src/utils.js'
 import type { WebRTCStar } from '../../src/index.js'
 import type { Listener, Upgrader } from '@libp2p/interface-transport'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
+import type { PeerTransport } from '../index.js'
 
 const protocol = '/echo/1.0.0'
 
-export default (create: () => Promise<WebRTCStar>) => {
+export default (create: () => Promise<PeerTransport>) => {
   describe('track connections', () => {
     let ws1: WebRTCStar
     let ws2: WebRTCStar
@@ -50,7 +51,7 @@ export default (create: () => Promise<WebRTCStar>) => {
       })
 
       // first
-      ws1 = await create()
+      ;({ transport: ws1 } = await create())
       listener = ws1.createListener({
         upgrader,
         handler: (conn) => {
@@ -62,7 +63,7 @@ export default (create: () => Promise<WebRTCStar>) => {
       })
 
       // second
-      ws2 = await create()
+      ;({ transport: ws2 } = await create())
       remoteListener = ws2.createListener({
         upgrader,
         handler: (conn) => {


### PR DESCRIPTION
Tweaks the logic around server errors so that if we lose our connection to the sigserver, we now let socket.io's reconnection logic handle trying to reconnect instead of emitting an error that causes everything to be torn down.

Fixes: #453