### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/packages/webrtc-star-transport/package.json
+++ b/packages/webrtc-star-transport/package.json
@@ -138,7 +138,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-peer-discovery": "^1.0.0",
     "@libp2p/interface-peer-id": "^1.0.2",
@@ -155,15 +154,15 @@
     "delay": "^5.0.0",
     "err-code": "^3.0.1",
     "iso-random-stream": "^2.0.2",
-    "multiformats": "^9.6.3",
+    "multiformats": "^10.0.0",
     "p-defer": "^4.0.0",
     "socket.io-client": "^4.1.2",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^6.0.0",
-    "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.1",
-    "@libp2p/interface-transport-compliance-tests": "^2.0.5",
+    "@libp2p/interface-mocks": "^7.0.1",
+    "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
+    "@libp2p/interface-transport-compliance-tests": "^3.0.0",
     "@libp2p/peer-id-factory": "^1.0.9",
     "@libp2p/webrtc-star-signalling-server": "^2.0.0",
     "@mapbox/node-pre-gyp": "^1.0.5",
@@ -176,7 +175,6 @@
     "p-event": "^5.0.1",
     "p-wait-for": "^5.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^3.0.0",
     "uint8arraylist": "^2.3.2",
     "util": "^0.12.4",
     "wrtc": "^0.4.6"

--- a/packages/webrtc-star-transport/test/browser.ts
+++ b/packages/webrtc-star-transport/test/browser.ts
@@ -1,19 +1,17 @@
 /* eslint-env mocha */
 
-import { WebRTCStar } from '../src/index.js'
+import { webRTCStar } from '../src/index.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import dialTests from './transport/dial.js'
 import listenTests from './transport/listen.js'
 import discoveryTests from './transport/discovery.js'
 import filterTests from './transport/filter.js'
-import { Components } from '@libp2p/components'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 
 describe('browser RTC', () => {
   const create = async () => {
     const peerId = await createEd25519PeerId()
-    const ws = new WebRTCStar()
-    ws.init(new Components({ peerId }))
+    const ws = webRTCStar()({ peerId })
 
     const registrar = mockRegistrar()
     const upgrader = mockUpgrader({ registrar })

--- a/packages/webrtc-star-transport/test/compliance.spec.ts
+++ b/packages/webrtc-star-transport/test/compliance.spec.ts
@@ -6,17 +6,15 @@ import sinon from 'sinon'
 import { multiaddr } from '@multiformats/multiaddr'
 import testsTransport from '@libp2p/interface-transport-compliance-tests'
 import testsDiscovery from '@libp2p/interface-peer-discovery-compliance-tests'
-import { WebRTCStar } from '../src/index.js'
+import { webRTCStar } from '../src/index.js'
 import pWaitFor from 'p-wait-for'
 import { peerIdFromString } from '@libp2p/peer-id'
-import { Components } from '@libp2p/components'
 
 describe('interface-transport compliance', function () {
   testsTransport({
     async setup () {
       const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-      const ws = new WebRTCStar({ wrtc })
-      ws.init(new Components({ peerId }))
+      const ws = webRTCStar({ wrtc })({ peerId })
 
       const base = (id: string) => {
         return `/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/${id}`
@@ -49,8 +47,7 @@ describe('interface-discovery compliance', () => {
   testsDiscovery({
     async setup () {
       const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d')
-      const ws = new WebRTCStar({ wrtc })
-      ws.init(new Components({ peerId }))
+      const ws = webRTCStar({ wrtc })({ peerId })
       const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d'
 
       const discovery = ws.discovery

--- a/packages/webrtc-star-transport/test/node.ts
+++ b/packages/webrtc-star-transport/test/node.ts
@@ -5,7 +5,7 @@ import wrtc from 'wrtc'
 // @ts-expect-error no types
 import electronWebRTC from 'electron-webrtc'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { WebRTCStar } from '../src/index.js'
+import { webRTCStar } from '../src/index.js'
 import dialTests from './transport/dial.js'
 import listenTests from './transport/listen.js'
 import discoveryTests from './transport/discovery.js'
@@ -13,7 +13,6 @@ import filterTests from './transport/filter.js'
 import multipleSignalServersTests from './transport/multiple-signal-servers.js'
 import trackTests from './transport/track.js'
 import reconnectTests from './transport/reconnect.node.js'
-import { Components } from '@libp2p/components'
 import type { PeerTransport } from './index.js'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 
@@ -24,10 +23,9 @@ process.on('beforeExit', (code) => process.exit(code))
 describe('transport: with wrtc', () => {
   const create = async (): Promise<PeerTransport> => {
     const peerId = await createEd25519PeerId()
-    const ws = new WebRTCStar({
+    const ws = webRTCStar({
       wrtc
-    })
-    ws.init(new Components({ peerId }))
+    })({ peerId })
 
     const registrar = mockRegistrar()
     const upgrader = mockUpgrader({ registrar })
@@ -53,10 +51,9 @@ describe('transport: with wrtc', () => {
 describe.skip('transport: with electron-webrtc', () => {
   const create = async () => {
     const peerId = await createEd25519PeerId()
-    const ws = new WebRTCStar({
+    const ws = webRTCStar({
       wrtc: electronWebRTC()
-    })
-    ws.init(new Components({ peerId }))
+    })({ peerId })
 
     const registrar = mockRegistrar()
     const upgrader = mockUpgrader({ registrar })

--- a/packages/webrtc-star-transport/test/transport/instance.spec.ts
+++ b/packages/webrtc-star-transport/test/transport/instance.spec.ts
@@ -1,16 +1,12 @@
 /* eslint-env mocha */
 
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
-import { WebRTCStar } from '../../src/index.js'
+import { webRTCStar } from '../../src/index.js'
 
 describe('instantiate the transport', () => {
-  it('create', () => {
-    const wstar = new WebRTCStar()
+  it('create', async () => {
+    const wstar = webRTCStar()({ peerId: await createEd25519PeerId() })
     expect(wstar).to.exist()
-  })
-
-  it('create without new', () => {
-    // @ts-expect-error WebRTCStar is a class and needs new
-    expect(() => WebRTCStar()).to.throw()
   })
 })


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection