### PR TITLE
fix: expose discovery as factory

### DIFF
--- a/packages/webrtc-star-transport/README.md
+++ b/packages/webrtc-star-transport/README.md
@@ -46,46 +46,59 @@ To use this module in Node.js, you have to BYOI of WebRTC, there are multiple op
 Instead of just creating the WebRTCStar instance without arguments, you need to pass an options object with the WebRTC implementation:
 
 ```JavaScript
+import { createLibp2pNode } from 'libp2p'
+import { webRTCStar } from '@libp2p/webrtc-star'
 import wrtc from 'wrtc'
 import electronWebRTC from 'electron-webrtc'
-import { WebRTCStar } from '@libp2p/webrtc-star'
 
-// Using wrtc
-const ws1 = new WebRTCStar({ wrtc: wrtc })
+// Using wrtc in node
+const transport = webRTCStar({ wrtc })
 
-// Using electron-webrtc
-const ws2 = new WebRTCStar({ wrtc: electronWebRTC() })
+// Using electron-webrtc in electron
+const transport = webRTCStar({ wrtc: electronWebRTC() })
+
+const node = await createLibp2pNode({
+  addresses: {
+    listen: [
+      '/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star'
+    ]
+  },
+  transports: [
+    transport
+  ],
+  peerDiscovery: [
+    transport.discovery
+  ]
+})
+await node.start()
+
+await node.dial('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
 ```
 
 ### Using this module in the Browser
 
 ```JavaScript
-import { WebRTCStar } from '@libp2p/webrtc-star'
-import { Multiaddr } from '@multiformats/multiaddr'
-import all from 'it-all'
+import { createLibp2pNode } from 'libp2p'
+import { webRTCStar } from '@libp2p/webrtc-star'
 
-const addr = multiaddr('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+const transport = webRTCStar()
 
-const ws = new WebRTCStar({ upgrader })
-
-const listener = ws.createListener((socket) => {
-  console.log('new connection opened')
-  pipe(
-    ['hello'],
-    socket
-  )
+const node = await createLibp2pNode({
+  addresses: {
+    listen: [
+      '/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star'
+    ]
+  },
+  transports: [
+    transport
+  ],
+  peerDiscovery: [
+    transport.discovery
+  ]
 })
+await node.start()
 
-await listener.listen(addr)
-console.log('listening')
-
-const socket = await ws.dial(addr)
-const values = await all(socket)
-
-console.log(`Value: ${values.toString()}`)
-
-// Close connection after reading
-await listener.close()
+await node.dial('/ip4/188.166.203.82/tcp/20000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
 ```
 
 ## Signalling server

--- a/packages/webrtc-star-transport/src/index.ts
+++ b/packages/webrtc-star-transport/src/index.ts
@@ -101,16 +101,8 @@ export class WebRTCStar implements Transport {
   public wrtc?: WRTC
   public discovery: () => PeerDiscovery & Startable
   public sigServers: Map<string, SignalServer>
-<<<<<<< Updated upstream
-  private readonly components: WebRTCStarComponents
-=======
-<<<<<<< Updated upstream
-  private components: Components = new Components()
-=======
   private readonly components: WebRTCStarComponents
   private readonly _discovery: WebRTCStarDiscovery
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
   constructor (components: WebRTCStarComponents, init?: WebRTCStarInit) {
     if (init?.wrtc != null) {

--- a/packages/webrtc-star-transport/src/index.ts
+++ b/packages/webrtc-star-transport/src/index.ts
@@ -99,9 +99,18 @@ export interface WebRTCStarComponents {
  */
 export class WebRTCStar implements Transport {
   public wrtc?: WRTC
-  public discovery: PeerDiscovery & Startable
+  public discovery: () => PeerDiscovery & Startable
   public sigServers: Map<string, SignalServer>
+<<<<<<< Updated upstream
   private readonly components: WebRTCStarComponents
+=======
+<<<<<<< Updated upstream
+  private components: Components = new Components()
+=======
+  private readonly components: WebRTCStarComponents
+  private readonly _discovery: WebRTCStarDiscovery
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
   constructor (components: WebRTCStarComponents, init?: WebRTCStarInit) {
     if (init?.wrtc != null) {
@@ -114,7 +123,8 @@ export class WebRTCStar implements Transport {
     this.sigServers = new Map()
 
     // Discovery
-    this.discovery = new WebRTCStarDiscovery()
+    this._discovery = new WebRTCStarDiscovery()
+    this.discovery = () => this._discovery
     this.peerDiscovered = this.peerDiscovered.bind(this)
   }
 
@@ -281,7 +291,7 @@ export class WebRTCStar implements Transport {
 
     const peerId = peerIdFromString(peerIdStr)
 
-    this.discovery.dispatchEvent(new CustomEvent('peer', {
+    this._discovery.dispatchEvent(new CustomEvent('peer', {
       detail: {
         id: peerId,
         multiaddrs: [ma],

--- a/packages/webrtc-star-transport/test/compliance.spec.ts
+++ b/packages/webrtc-star-transport/test/compliance.spec.ts
@@ -50,7 +50,7 @@ describe('interface-discovery compliance', () => {
       const ws = webRTCStar({ wrtc })({ peerId })
       const maStr = '/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2d'
 
-      const discovery = ws.discovery
+      const discovery = ws.discovery()
       running = true
 
       // only discover peers while the test is running and after discovery has been started
@@ -71,7 +71,7 @@ describe('interface-discovery compliance', () => {
           }
         })
 
-      return ws.discovery
+      return discovery
     },
     async teardown () {
       running = false

--- a/packages/webrtc-star-transport/test/transport/discovery.ts
+++ b/packages/webrtc-star-transport/test/transport/discovery.ts
@@ -28,7 +28,7 @@ export default (create: () => Promise<PeerTransport>) => {
     it('listen on the first', async () => {
       ({ transport: ws1 } = await create())
       ws1Listener = ws1.createListener({ upgrader: mockUpgrader() })
-      await ws1.discovery.start()
+      await ws1.discovery().start()
 
       await ws1Listener.listen(signallerAddr)
     })
@@ -36,10 +36,10 @@ export default (create: () => Promise<PeerTransport>) => {
     it('listen on the second, discover the first', async () => {
       ({ transport: ws2 } = await create())
       const listener = ws2.createListener({ upgrader: mockUpgrader() })
-      await ws2.discovery.start()
+      await ws2.discovery().start()
 
       await listener.listen(signallerAddr)
-      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery, 'peer')
+      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery(), 'peer')
 
       // Check first of the signal addresses
       const [sigRefs] = ws2.sigServers.values()
@@ -59,7 +59,7 @@ export default (create: () => Promise<PeerTransport>) => {
 
       let discoveredPeer = false
 
-      ws1.discovery.addEventListener('peer', () => {
+      ws1.discovery().addEventListener('peer', () => {
         discoveredPeer = true
       }, {
         once: true
@@ -67,7 +67,7 @@ export default (create: () => Promise<PeerTransport>) => {
 
       ;({ transport: ws3 } = await create())
       const listener = ws3.createListener({ upgrader: mockUpgrader() })
-      await ws3.discovery.start()
+      await ws3.discovery().start()
 
       await listener.listen(signallerAddr)
       await pEvent(server.socket, 'ws-peer')
@@ -86,16 +86,16 @@ export default (create: () => Promise<PeerTransport>) => {
 
       let discoveredPeer = false
 
-      ws1.discovery.addEventListener('peer', () => {
+      ws1.discovery().addEventListener('peer', () => {
         discoveredPeer = true
       }, {
         once: true
       })
 
-      void ws1.discovery.stop()
+      void ws1.discovery().stop()
       ;({ transport: ws4 } = await create())
       const listener = ws4.createListener({ upgrader: mockUpgrader() })
-      void ws4.discovery.start()
+      void ws4.discovery().start()
 
       await listener.listen(signallerAddr)
       await pEvent(server.socket, 'ws-peer')

--- a/packages/webrtc-star-transport/test/transport/reconnect.node.ts
+++ b/packages/webrtc-star-transport/test/transport/reconnect.node.ts
@@ -53,7 +53,7 @@ export default (create: () => Promise<PeerTransport>) => {
       ({ transport: ws1 } = await create())
 
       listener1 = ws1.createListener({ upgrader: mockUpgrader() })
-      await ws1.discovery.start()
+      await ws1.discovery().start()
 
       await listener1.listen(signallerAddr)
     })
@@ -64,7 +64,7 @@ export default (create: () => Promise<PeerTransport>) => {
       listener2 = ws2.createListener({ upgrader: mockUpgrader() })
 
       await listener2.listen(signallerAddr)
-      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery, 'peer')
+      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery(), 'peer')
 
       // Check first of the signal addresses
       const [sigRefs] = ws2.sigServers.values()
@@ -90,7 +90,7 @@ export default (create: () => Promise<PeerTransport>) => {
       listener3 = ws3.createListener({ upgrader: mockUpgrader() })
       await listener3.listen(signallerAddr)
 
-      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery, 'peer')
+      const { detail: { multiaddrs } } = await pEvent<'peer', { detail: { multiaddrs: Multiaddr[] } }>(ws1.discovery(), 'peer')
 
       // Check first of the signal addresses
       const [sigRefs] = ws3.sigServers.values()
@@ -135,7 +135,7 @@ export default (create: () => Promise<PeerTransport>) => {
         const peer2Discovered = pDefer()
         const peer3Discovered = pDefer()
 
-        peer1.transport.discovery.addEventListener('peer', event => {
+        peer1.transport.discovery().addEventListener('peer', event => {
           const discoveredPeer = event.detail.id
 
           if (discoveredPeer.equals(peer2.peerId)) {
@@ -159,7 +159,7 @@ export default (create: () => Promise<PeerTransport>) => {
       // listen on the first
       const peer1 = await create()
       listener1 = peer1.transport.createListener({ upgrader: mockUpgrader() })
-      await peer1.transport.discovery.start()
+      await peer1.transport.discovery().start()
       await listener1.listen(signallerAddr)
 
       // wait for peer discovery


### PR DESCRIPTION
To use the same interface as other libp2p components, expose the discovery module as a factory function.